### PR TITLE
RESTful API 문서화 및 표준화를 위한 Swagger 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/husk/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package kr.husk.infrastructure.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(title = "HUSK WAS", description = "HUSK API 명세입니다.", version = "v1")
+)
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public GroupedOpenApi openApi() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+                .group("HUSK API v1")
+                .pathsToMatch(paths)
+                .build();
+    }
+}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->

RESTful API 표준화 및 문서화, Front-End와의 커뮤니케이션 향상을 위한 OAS 문서 연동.

## Problem Solving

<!-- 해결 방법 -->

SwaggerConfig 설정 파일 작성 및 관련 외부 의존성 추가.


## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

정상적으로 localhost:8080/swagger-ui/index.html 페이지 접속이 되는 것을 확인했습니다.
JWT 기반 보안 인증은 적용하지 않았습니다.
