### PR TITLE
인증 코드 전송 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    // email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/husk/application/auth/dto/SendAuthCode.java
+++ b/src/main/java/kr/husk/application/auth/dto/SendAuthCode.java
@@ -1,0 +1,40 @@
+package kr.husk.application.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import kr.husk.domain.auth.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+public class SendAuthCode {
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "SendAuthCode.Request", description = "인증 코드 전송 요청 DTO")
+    public static class Request {
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "이메일", example = "team.dopamine.dev@gmail.com")
+        private String email;
+
+        public User toEntity() {
+            return User.builder()
+                    .email(email)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "SendAuthCode.Response", description = "인증 코드 전송 응답 DTO")
+    public static class Response {
+        @Setter
+        @Schema(description = "응답 메시지", example = "인증 코드가 전송되었습니다.")
+        private String message;
+
+        public static Response of(String message) {
+            return new Response(message);
+        }
+    }
+}

--- a/src/main/java/kr/husk/application/auth/dto/SendAuthCodeDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SendAuthCodeDto.java
@@ -6,10 +6,12 @@ import jakarta.validation.constraints.NotBlank;
 import kr.husk.domain.auth.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class SendAuthCodeDto {
     @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     @Schema(name = "SendAuthCode.Request", description = "인증 코드 전송 요청 DTO")
     public static class Request {

--- a/src/main/java/kr/husk/application/auth/dto/SendAuthCodeDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SendAuthCodeDto.java
@@ -8,7 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-public class SendAuthCode {
+public class SendAuthCodeDto {
     @Getter
     @AllArgsConstructor
     @Schema(name = "SendAuthCode.Request", description = "인증 코드 전송 요청 DTO")

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -1,34 +1,47 @@
 package kr.husk.application.auth.service;
 
 import kr.husk.domain.auth.repository.AuthCodeRepository;
+import kr.husk.domain.auth.service.UserService;
 import kr.husk.infrastructure.config.AuthConfig;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
     private final AuthConfig authConfig;
     private final JavaMailSender mailSender;
+    private final UserService userService;
     private final AuthCodeRepository authCodeRepository;
 
-    public void sendAuthCode(String to) {
-        // 1. 인증코드 생성
+    @Transactional
+    public String sendAuthCode(String to) {
+        if (userService.isExist(to)) {
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
+
         String authCode = generateAuthCode();
         authCodeRepository.create(to, authCode, authConfig.getCodeExpiration());
 
-        // 2. 이메일 전송
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(to);
-        message.setSubject("[HUSK] 회원가입을 위한 인증코드 발송");
-        message.setText("인증코드: " + authCode);
-        mailSender.send(message);
+        try {
+            sendEmail(to, authCode);
+            log.info("인증 코드가 성공적으로 전송되었습니다. 이메일: {}", to);
+        } catch (Exception e) {
+            log.error("이메일 전송 실패. 이메일: {}", to, e);
+            throw new RuntimeException("이메일 전송에 실패했습니다.");
+        }
+
+        return authCode;
     }
 
+    @Transactional
     public boolean verifyAuthCode(String email, String code) {
         String savedCode = authCodeRepository.read(authConfig.getKeyPrefix() + email);
         if (savedCode != null && savedCode.equals(code)) {
@@ -40,5 +53,13 @@ public class AuthService {
 
     private String generateAuthCode() {
         return String.format("%06d", new Random().nextInt(999999));
+    }
+
+    private void sendEmail(String to, String authCode) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("[HUSK] 회원가입을 위한 인증코드 발송");
+        message.setText("인증코드: " + authCode);
+        mailSender.send(message);
     }
 }

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package kr.husk.application.auth.service;
 
+import kr.husk.application.auth.dto.SendAuthCodeDto;
 import kr.husk.domain.auth.repository.AuthCodeRepository;
 import kr.husk.domain.auth.service.UserService;
 import kr.husk.infrastructure.config.AuthConfig;
@@ -22,23 +23,23 @@ public class AuthService {
     private final AuthCodeRepository authCodeRepository;
 
     @Transactional
-    public String sendAuthCode(String to) {
-        if (userService.isExist(to)) {
+    public SendAuthCodeDto.Response sendAuthCode(SendAuthCodeDto.Request dto) {
+        if (userService.isExist(dto.getEmail())) {
             throw new IllegalArgumentException("이미 가입된 이메일입니다.");
         }
 
         String authCode = generateAuthCode();
-        authCodeRepository.create(to, authCode, authConfig.getCodeExpiration());
+        authCodeRepository.create(dto.getEmail(), authCode, authConfig.getCodeExpiration());
 
         try {
-            sendEmail(to, authCode);
-            log.info("인증 코드가 성공적으로 전송되었습니다. 이메일: {}", to);
+            sendEmail(dto.getEmail(), authCode);
+            log.info("인증 코드가 성공적으로 전송되었습니다. 이메일: {}", dto.getEmail());
         } catch (Exception e) {
-            log.error("이메일 전송 실패. 이메일: {}", to, e);
+            log.error("이메일 전송 실패. 이메일: {}", dto.getEmail(), e);
             throw new RuntimeException("이메일 전송에 실패했습니다.");
         }
 
-        return authCode;
+        return SendAuthCodeDto.Response.of("인증 코드가 성공적으로 전송되었습니다.");
     }
 
     @Transactional

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -5,6 +5,8 @@ import kr.husk.infrastructure.config.AuthConfig;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Random;
+
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -25,5 +27,9 @@ public class AuthService {
             return true;
         }
         return false;
+    }
+
+    private String generateAuthCode() {
+        return String.format("%06d", new Random().nextInt(999999));
     }
 }

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -3,6 +3,8 @@ package kr.husk.application.auth.service;
 import kr.husk.domain.auth.repository.AuthCodeRepository;
 import kr.husk.infrastructure.config.AuthConfig;
 import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.util.Random;
@@ -11,13 +13,20 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class AuthService {
     private final AuthConfig authConfig;
+    private final JavaMailSender mailSender;
     private final AuthCodeRepository authCodeRepository;
 
-    public void sendAuthCode(String key, String code) {
+    public void sendAuthCode(String to) {
         // 1. 인증코드 생성
-        authCodeRepository.create(key, code, authConfig.getCodeExpiration());
+        String authCode = generateAuthCode();
+        authCodeRepository.create(to, authCode, authConfig.getCodeExpiration());
 
-        // 2. 이메일 전송 (추후 구현)
+        // 2. 이메일 전송
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("[HUSK] 회원가입을 위한 인증코드 발송");
+        message.setText("인증코드: " + authCode);
+        mailSender.send(message);
     }
 
     public boolean verifyAuthCode(String email, String code) {

--- a/src/main/java/kr/husk/domain/auth/repository/UserRepository.java
+++ b/src/main/java/kr/husk/domain/auth/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package kr.husk.domain.auth.repository;
+
+import kr.husk.domain.auth.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/kr/husk/domain/auth/service/UserService.java
+++ b/src/main/java/kr/husk/domain/auth/service/UserService.java
@@ -1,0 +1,17 @@
+package kr.husk.domain.auth.service;
+
+import kr.husk.domain.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public boolean isExist(String email) {
+        return userRepository.findByEmail(email).isPresent();
+    }
+}

--- a/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package kr.husk.infrastructure.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity(debug = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authorizeHttpRequests ->
+                        authorizeHttpRequests.requestMatchers(
+                                        "/auth/send-code",
+                                        "/swagger-resources/**",
+                                        "/swagger-ui/**",
+                                        "/v3/api-docs/**",
+                                        "/webjars/**",
+                                        "/error").permitAll()
+                                .anyRequest().authenticated());
+
+        return httpSecurity.build();
+    }
+}

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -1,17 +1,25 @@
 package kr.husk.presentation.api;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import kr.husk.application.auth.dto.SendAuthCode;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.husk.application.auth.dto.SendAuthCodeDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
+@Tag(name = "[인증 관련 API]", description = "사용자 인증 관련 API")
 public interface AuthApi {
     @Operation(summary = "인증 코드 전송", description = "이메일로 인증 코드를 전송하기 위한 API")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "인증 코드 전송 성공"),
+            @ApiResponse(responseCode = "200", description = "인증 코드 전송 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = SendAuthCodeDto.Response.class)
+                    )
+            ),
             @ApiResponse(responseCode = "400", description = "인증 코드 전송 실패")
     })
-    ResponseEntity<?> sendAuthCode(@RequestBody SendAuthCode.Request dto);
+    ResponseEntity<?> sendAuthCode(@RequestBody SendAuthCodeDto.Request dto);
 }

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -1,0 +1,17 @@
+package kr.husk.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import kr.husk.application.auth.dto.SendAuthCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface AuthApi {
+    @Operation(summary = "인증 코드 전송", description = "이메일로 인증 코드를 전송하기 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 코드 전송 성공"),
+            @ApiResponse(responseCode = "400", description = "인증 코드 전송 실패")
+    })
+    ResponseEntity<?> sendAuthCode(@RequestBody SendAuthCode.Request dto);
+}

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -1,0 +1,23 @@
+package kr.husk.presentation.rest;
+
+import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.service.AuthService;
+import kr.husk.presentation.api.AuthApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController implements AuthApi {
+    private final AuthService authService;
+
+    @Override
+    @PostMapping("/send-code")
+    public ResponseEntity<?> sendAuthCode(SendAuthCodeDto.Request dto) {
+        return ResponseEntity.ok(authService.sendAuthCode(dto));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,17 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+  mail:
+    host: ${MAIL_HOST}
+    port: ${MAIL_PORT}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 husk:
   auth:

--- a/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
+++ b/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
@@ -1,0 +1,45 @@
+package kr.husk.presentation.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void sendAuthCodeApiTest() throws Exception {
+        // give
+        SendAuthCodeDto.Request dto = new SendAuthCodeDto.Request("jinlee1703@gmail.com");
+
+        // when
+        when(authService.sendAuthCode(dto)).thenReturn(SendAuthCodeDto.Response.of("인증 코드가 성공적으로 전송되었습니다."));
+
+        // then
+        mockMvc.perform(post("/auth/send-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk());
+
+    }
+}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->

- 회원 가입 이전 계정 검증 여부 필요성 대두
- 이메일 검증을 통한 중복 회원 최소화 및 계정 유효성 검증

## Problem Solving

<!-- 해결 방법 -->

1. `UserService` (도메인 서비스) - 회원 존재 여부 검증
2. `AuthService` (유스케이스) - 인증 코드 저장 및 이메일 전송
3. `AuthController` (REST API) - 인증 코드 전송 API 구현
4. `AuthApi` (OAS Docs) - 인증 코드 전송 API Docs 작성

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

<img width="1420" alt="image" src="https://github.com/user-attachments/assets/acac8969-2b16-4107-90bc-1791ba33c601">

- `SecurityConfig` 정의하여 swagger 및 특정 api 요청 시 인증 생략하도록 설정하였습니다.
  - Swagger의 경우 CSRF 공격에 대해 취약해지기 때문에 추후 접근 가능한 계정을 별도로 생성해놓아도 좋을 것 같아요.
- [참고자료](https://velog.io/@tjddus0302/Spring-Boot-%EB%A9%94%EC%9D%BC-%EB%B0%9C%EC%86%A1-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-Gmail)에서 Google Mail 설정 참고하였습니다. 
- API를 구현하고 보니 GlobalExceptionHandler를 통한 예외 핸들링을 하면 좋을 것 같다는 생각이 드네요, 이야기 나눠봐도 좋을 것 같습니다.
- 테스트 코드 실행 시 body 검증이 올바르게 되지 않고 있어, 해당 부분 제외하였습니다. 추후 테스트 환경에 대해 이야기 나눠본 후 수정하면 좋을 것 같습니다.
  <img width="649" alt="image" src="https://github.com/user-attachments/assets/e079b7ae-bff3-400a-a889-00f0d31d9556">