### PR TITLE
feature/HK-46: 인증 코드 검증 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/auth/dto/VerifyAuthCodeDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/VerifyAuthCodeDto.java
@@ -29,8 +29,8 @@ public class VerifyAuthCodeDto {
     public static class Response {
         private String message;
 
-        public static Response of(boolean isVerified) {
-            return new Response(isVerified ? "인증에 성공했습니다." : "인증에 실패했습니다.");
+        public static Response of(String message) {
+            return new Response(message);
         }
     }
 }

--- a/src/main/java/kr/husk/application/auth/dto/VerifyAuthCodeDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/VerifyAuthCodeDto.java
@@ -27,10 +27,10 @@ public class VerifyAuthCodeDto {
     @AllArgsConstructor
     @Schema(name = "VerifyAuthCode.Response", description = "인증 코드 검증 응답 DTO")
     public static class Response {
-        private boolean message;
+        private String message;
 
-        public static Response of(boolean message) {
-            return new Response(message);
+        public static Response of(boolean isVerified) {
+            return new Response(isVerified ? "인증에 성공했습니다." : "인증에 실패했습니다.");
         }
     }
 }

--- a/src/main/java/kr/husk/application/auth/dto/VerifyAuthCodeDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/VerifyAuthCodeDto.java
@@ -1,0 +1,36 @@
+package kr.husk.application.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class VerifyAuthCodeDto {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "VerifyAuthCode.Request", description = "인증 코드 검증 요청 DTO")
+    public static class Request {
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "이메일", example = "team.dopamine.dev@gmail.com")
+        private String email;
+
+        @NotBlank(message = "인증 코드는 필수 입력값입니다.")
+        @Schema(description = "인증 코드", example = "123456")
+        private String authCode;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "VerifyAuthCode.Response", description = "인증 코드 검증 응답 DTO")
+    public static class Response {
+        private boolean message;
+
+        public static Response of(boolean message) {
+            return new Response(message);
+        }
+    }
+}

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
         }
 
         String authCode = generateAuthCode();
-        authCodeRepository.create(dto.getEmail(), authCode, authConfig.getCodeExpiration());
+        authCodeRepository.create(dto.getEmail(), authCode);
 
         try {
             sendEmail(dto.getEmail(), authCode);
@@ -45,14 +45,14 @@ public class AuthService {
 
     @Transactional
     public VerifyAuthCodeDto.Response verifyAuthCode(VerifyAuthCodeDto.Request dto) {
-        String savedCode = authCodeRepository.read(authConfig.getKeyPrefix() + dto.getEmail());
+        String savedCode = authCodeRepository.read(dto.getEmail());
         if (savedCode != null && savedCode.equals(dto.getAuthCode())) {
-            authCodeRepository.delete(authConfig.getKeyPrefix() + dto.getEmail());
+            authCodeRepository.delete(dto.getEmail());
             log.info("인증에 성공했습니다. 이메일: {}", dto.getEmail());
-            return VerifyAuthCodeDto.Response.of(true);
+            return VerifyAuthCodeDto.Response.of("인증에 성공했습니다.");
         }
         log.error("인증에 실패했습니다. 이메일: {}", dto.getEmail());
-        return VerifyAuthCodeDto.Response.of(false);
+        throw new IllegalArgumentException("인증에 실패했습니다.");
     }
 
     private String generateAuthCode() {

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -48,8 +48,10 @@ public class AuthService {
         String savedCode = authCodeRepository.read(authConfig.getKeyPrefix() + dto.getEmail());
         if (savedCode != null && savedCode.equals(dto.getAuthCode())) {
             authCodeRepository.delete(authConfig.getKeyPrefix() + dto.getEmail());
+            log.info("인증에 성공했습니다. 이메일: {}", dto.getEmail());
             return VerifyAuthCodeDto.Response.of(true);
         }
+        log.error("인증에 실패했습니다. 이메일: {}", dto.getEmail());
         return VerifyAuthCodeDto.Response.of(false);
     }
 

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package kr.husk.application.auth.service;
 
 import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.domain.auth.repository.AuthCodeRepository;
 import kr.husk.domain.auth.service.UserService;
 import kr.husk.infrastructure.config.AuthConfig;
@@ -43,13 +44,13 @@ public class AuthService {
     }
 
     @Transactional
-    public boolean verifyAuthCode(String email, String code) {
-        String savedCode = authCodeRepository.read(authConfig.getKeyPrefix() + email);
-        if (savedCode != null && savedCode.equals(code)) {
-            authCodeRepository.delete(authConfig.getKeyPrefix() + email);
-            return true;
+    public VerifyAuthCodeDto.Response verifyAuthCode(VerifyAuthCodeDto.Request dto) {
+        String savedCode = authCodeRepository.read(authConfig.getKeyPrefix() + dto.getEmail());
+        if (savedCode != null && savedCode.equals(dto.getAuthCode())) {
+            authCodeRepository.delete(authConfig.getKeyPrefix() + dto.getEmail());
+            return VerifyAuthCodeDto.Response.of(true);
         }
-        return false;
+        return VerifyAuthCodeDto.Response.of(false);
     }
 
     private String generateAuthCode() {

--- a/src/main/java/kr/husk/domain/auth/repository/AuthCodeRepository.java
+++ b/src/main/java/kr/husk/domain/auth/repository/AuthCodeRepository.java
@@ -1,7 +1,7 @@
 package kr.husk.domain.auth.repository;
 
 public interface AuthCodeRepository {
-    void create(String key, String code, long expireTime);
+    void create(String key, String code);
 
     String read(String key);
 

--- a/src/main/java/kr/husk/infrastructure/config/AuthConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/AuthConfig.java
@@ -18,6 +18,6 @@ public class AuthConfig {
 
     @Bean
     public AuthCodeRepository authCodeRepository() {
-        return new ConcurrentMapAuthCodeRepository();
+        return new ConcurrentMapAuthCodeRepository(this);
     }
 }

--- a/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
@@ -18,6 +18,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizeHttpRequests ->
                         authorizeHttpRequests.requestMatchers(
                                         "/auth/send-code",
+                                        "/auth/verify-code",
                                         "/swagger-resources/**",
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",

--- a/src/main/java/kr/husk/infrastructure/persistence/ConcurrentMapAuthCodeRepository.java
+++ b/src/main/java/kr/husk/infrastructure/persistence/ConcurrentMapAuthCodeRepository.java
@@ -1,6 +1,8 @@
 package kr.husk.infrastructure.persistence;
 
 import kr.husk.domain.auth.repository.AuthCodeRepository;
+import kr.husk.infrastructure.config.AuthConfig;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -9,23 +11,25 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @Repository
+@RequiredArgsConstructor
 public class ConcurrentMapAuthCodeRepository implements AuthCodeRepository {
+    private final AuthConfig authConfig;
     private final ConcurrentHashMap<String, String> authCodeMap = new ConcurrentHashMap<>();
     private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
     @Override
-    public void create(String key, String code, long expireTime) {
-        authCodeMap.put(key, code);
-        scheduledExecutorService.schedule(() -> authCodeMap.remove(key), expireTime, TimeUnit.MILLISECONDS);
+    public void create(String key, String code) {
+        authCodeMap.put(authConfig.getKeyPrefix() + key, code);
+        scheduledExecutorService.schedule(() -> authCodeMap.remove(key), authConfig.getCodeExpiration(), TimeUnit.MILLISECONDS);
     }
 
     @Override
     public String read(String key) {
-        return authCodeMap.get(key);
+        return authCodeMap.get(authConfig.getKeyPrefix() + key);
     }
 
     @Override
     public void delete(String key) {
-        authCodeMap.remove(key);
+        authCodeMap.remove(authConfig.getKeyPrefix() + key);
     }
 }

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -22,4 +22,11 @@ public interface AuthApi {
             @ApiResponse(responseCode = "400", description = "인증 코드 전송 실패")
     })
     ResponseEntity<?> sendAuthCode(@RequestBody SendAuthCodeDto.Request dto);
+
+    @Operation(summary = "인증 코드 검증", description = "이메일로 전송된 인증 코드를 검증하기 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 코드 검증 성공"),
+            @ApiResponse(responseCode = "400", description = "인증 코드 검증 실패")
+    })
+    ResponseEntity<?> verifyAuthCode(@RequestBody SendAuthCodeDto.Request dto);
 }

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -28,5 +29,5 @@ public interface AuthApi {
             @ApiResponse(responseCode = "200", description = "인증 코드 검증 성공"),
             @ApiResponse(responseCode = "400", description = "인증 코드 검증 실패")
     })
-    ResponseEntity<?> verifyAuthCode(@RequestBody SendAuthCodeDto.Request dto);
+    ResponseEntity<?> verifyAuthCode(@RequestBody VerifyAuthCodeDto.Request dto);
 }

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -1,6 +1,7 @@
 package kr.husk.presentation.rest;
 
 import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.application.auth.service.AuthService;
 import kr.husk.presentation.api.AuthApi;
 import lombok.RequiredArgsConstructor;
@@ -19,5 +20,11 @@ public class AuthController implements AuthApi {
     @PostMapping("/send-code")
     public ResponseEntity<?> sendAuthCode(SendAuthCodeDto.Request dto) {
         return ResponseEntity.ok(authService.sendAuthCode(dto));
+    }
+
+    @Override
+    @PostMapping("/verify-code")
+    public ResponseEntity<?> verifyAuthCode(VerifyAuthCodeDto.Request dto) {
+        return ResponseEntity.ok(authService.verifyAuthCode(dto.getEmail(), dto.getAuthCode()));
     }
 }

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -25,6 +25,6 @@ public class AuthController implements AuthApi {
     @Override
     @PostMapping("/verify-code")
     public ResponseEntity<?> verifyAuthCode(VerifyAuthCodeDto.Request dto) {
-        return ResponseEntity.ok(authService.verifyAuthCode(dto.getEmail(), dto.getAuthCode()));
+        return ResponseEntity.ok(authService.verifyAuthCode(dto));
     }
 }

--- a/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
+++ b/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
@@ -2,6 +2,7 @@ package kr.husk.presentation.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.application.auth.service.AuthService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +41,20 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isOk());
+    }
 
+    @Test
+    void verifyAuthCodeApiTest() throws Exception {
+        // give
+        VerifyAuthCodeDto.Request dto = new VerifyAuthCodeDto.Request("jinlee1703@gmail.com", "123456");
+
+        // when
+        when(authService.verifyAuthCode(dto)).thenReturn(VerifyAuthCodeDto.Response.of(true));
+
+        // then
+        mockMvc.perform(post("/auth/verify-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
+++ b/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
@@ -49,7 +49,7 @@ class AuthControllerTest {
         VerifyAuthCodeDto.Request dto = new VerifyAuthCodeDto.Request("jinlee1703@gmail.com", "123456");
 
         // when
-        when(authService.verifyAuthCode(dto)).thenReturn(VerifyAuthCodeDto.Response.of(true));
+        when(authService.verifyAuthCode(dto)).thenReturn(VerifyAuthCodeDto.Response.of("인증에 성공했습니다."));
 
         // then
         mockMvc.perform(post("/auth/verify-code")


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->

- 회원 가입을 위한 이메일 인증 후 이를 검증(본인 확인)하기 위한 기능 필요성 대두

## Problem Solving

<!-- 해결 방법 -->

- 인증 코드 검증 API 구현
- 인증 코드 검증 API CSRF 허용

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 인증 코드 검증 성공/실패 응답 확인 했습니다!
- 현재 테스트 코드의 경우, 커버리지가 많이 부족하다고 생각해서 이에 대해 추후 방안을 세워봤으면 좋겠습니다!
- API 응답 성공 메시지를 관리하는 주체를 어디에 두는 게 좋을 지 고민이 됩니다.