### PR TITLE
WAS 구성 데이터 및 중요 정보 중앙화를 위한 AWS Parameter Store 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,11 +36,16 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    //swagger
+    // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
     // email
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    //AWS Parameter Store
+    implementation(platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.2.0"))
+    implementation("io.awspring.cloud:spring-cloud-aws-starter")
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-parameter-store")
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,10 @@
 spring:
+  config:
+    import: 'aws-parameterstore:/config/husk/'
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=UTC
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: ${jdbc.url}
+    username: ${jdbc.username}
+    password: ${jdbc.password}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
@@ -12,10 +14,10 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
   mail:
-    host: ${MAIL_HOST}
-    port: ${MAIL_PORT}
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
+    host: ${mail.host}
+    port: ${mail.port}
+    username: ${mail.username}
+    password: ${mail.password}
     properties:
       mail:
         smtp:
@@ -25,5 +27,11 @@ spring:
 
 husk:
   auth:
-    code-expiration: ${AUTH_CODE_EXPIRATION}
-    key-prefix: ${AUTH_CODE_KEY_PREFIX}
+    code-expiration: ${auth.code.expiration}
+    key-prefix: ${auth.code.prefix}
+
+aws:
+  paramstore:
+    enabled: true
+    prefix: /config
+    name: husk


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- WAS 구성 데이터 및 중요 정보를 중앙화 하기 위해 Parameter Store 도입.
- Parameter Store 적용으로 WAS의 구성을 안전하고 쉽게 관리.
- application.yml 및 환경 변수 최신화에 대한 편의성 추구.

## Problem Solving

<!-- 해결 방법 -->
- Parameter Store 관련 의존성 주입
- application.yml 환경 변수 값을 AWS Parameter Store에서 파라미터 생성을 통해 치환함.

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 의존성 추가 및 application.yml 수정만 하다보니 line수는 적습니다!

- Slack에서 말씀드렸던 이슈는 AWS CLI를 설치하여 Local에서 access-key 및 secret-key를 적용하니 해결된 것으로 생각됩니다.
  - 특별히 설정을 수정하고 추가했던 부분은 없었기 때문인데 해당 PR이 merge 되면 다른 환경에서 확인해보도록 하겠습니다.

- Parameter Store에 Parameter 생성 시 이름 관련하여 Convention이 필요할 것 같습니다. 
  - 현재는 설정 값이 많지 않아서 우선 제 임의로 작성을 했는데 추후 `GlobalException`에 대한 작업을 함께 진행하면서 얘기나눠 보면 좋을 것 같아요 😄 