### PR TITLE
Feature(HK-41): 일반 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'

--- a/src/main/java/kr/husk/HuskApplication.java
+++ b/src/main/java/kr/husk/HuskApplication.java
@@ -2,8 +2,10 @@ package kr.husk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class HuskApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/kr/husk/application/auth/dto/SignUpDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SignUpDto.java
@@ -3,6 +3,7 @@ package kr.husk.application.auth.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import kr.husk.domain.auth.entity.User;
 import kr.husk.domain.auth.type.OAuthProvider;
 import lombok.AllArgsConstructor;
@@ -22,6 +23,8 @@ public class SignUpDto {
         private String email;
 
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()-_=+]).{8,16}$",
+                message = "비밀번호는 8자 이상 16자 이하이며, 숫자, 소문자, 대문자, 특수문자를 포함해야 합니다.")
         private String password;
 
         public User toEntity() {

--- a/src/main/java/kr/husk/application/auth/dto/SignUpDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SignUpDto.java
@@ -1,0 +1,48 @@
+package kr.husk.application.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import kr.husk.domain.auth.entity.User;
+import kr.husk.domain.auth.type.OAuthProvider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class SignUpDto {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "SignUp.Request", description = "회원가입 요청 DTO")
+    public static class Request {
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "이메일", example = "team.dopamine.dev@gmail.com")
+        private String email;
+
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        private String password;
+
+        public User toEntity() {
+            return User.builder()
+                    .email(email)
+                    .password(password)
+                    .oAuthProvider(OAuthProvider.NONE)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "SignUp.Response", description = "회원가입 응답 DTO")
+    public static class Response {
+        @Setter
+        @Schema(description = "응답 메시지", example = "회원가입에 성공했습니다.")
+        private String message;
+
+        public static Response of(String message) {
+            return new Response(message);
+        }
+    }
+}

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -3,7 +3,6 @@ package kr.husk.application.auth.service;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.domain.auth.repository.AuthCodeRepository;
-import kr.husk.domain.auth.service.UserService;
 import kr.husk.infrastructure.config.AuthConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -1,8 +1,10 @@
 package kr.husk.application.auth.service;
 
 import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.domain.auth.repository.AuthCodeRepository;
+import kr.husk.domain.auth.type.OAuthProvider;
 import kr.husk.infrastructure.config.AuthConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +26,7 @@ public class AuthService {
 
     @Transactional
     public SendAuthCodeDto.Response sendAuthCode(SendAuthCodeDto.Request dto) {
-        if (userService.isExist(dto.getEmail())) {
+        if (userService.isExist(dto.getEmail(), OAuthProvider.NONE)) {
             throw new IllegalArgumentException("이미 가입된 이메일입니다.");
         }
 
@@ -52,6 +54,15 @@ public class AuthService {
         }
         log.error("인증에 실패했습니다. 이메일: {}", dto.getEmail());
         throw new IllegalArgumentException("인증에 실패했습니다.");
+    }
+
+    @Transactional
+    public SignUpDto.Response signUp(SignUpDto.Request dto) {
+        if (userService.isExist(dto.getEmail(), OAuthProvider.NONE)) {
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
+        log.info("회원가입에 성공했습니다. 이메일: {}", dto.getEmail());
+        return SignUpDto.Response.of("회원가입에 성공했습니다.");
     }
 
     private String generateAuthCode() {

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package kr.husk.application.auth.service;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
 import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
+import kr.husk.domain.auth.entity.User;
 import kr.husk.domain.auth.repository.AuthCodeRepository;
 import kr.husk.domain.auth.service.UserService;
 import kr.husk.domain.auth.type.OAuthProvider;
@@ -62,7 +63,9 @@ public class AuthService {
         if (userService.isExist(dto.getEmail(), OAuthProvider.NONE)) {
             throw new IllegalArgumentException("이미 가입된 이메일입니다.");
         }
-        userService.create(dto.toEntity());
+        User user = dto.toEntity();
+        user.encodePassword(authConfig.passwordEncoder());
+        userService.create(user);
         log.info("회원가입에 성공했습니다. 이메일: {}", dto.getEmail());
         return SignUpDto.Response.of("회원가입에 성공했습니다.");
     }

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import kr.husk.application.auth.dto.SendAuthCodeDto;
 import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.domain.auth.repository.AuthCodeRepository;
+import kr.husk.domain.auth.service.UserService;
 import kr.husk.domain.auth.type.OAuthProvider;
 import kr.husk.infrastructure.config.AuthConfig;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -62,6 +62,7 @@ public class AuthService {
         if (userService.isExist(dto.getEmail(), OAuthProvider.NONE)) {
             throw new IllegalArgumentException("이미 가입된 이메일입니다.");
         }
+        userService.create(dto.toEntity());
         log.info("회원가입에 성공했습니다. 이메일: {}", dto.getEmail());
         return SignUpDto.Response.of("회원가입에 성공했습니다.");
     }

--- a/src/main/java/kr/husk/application/auth/service/UserService.java
+++ b/src/main/java/kr/husk/application/auth/service/UserService.java
@@ -1,4 +1,4 @@
-package kr.husk.domain.auth.service;
+package kr.husk.application.auth.service;
 
 import kr.husk.domain.auth.entity.User;
 import kr.husk.domain.auth.repository.UserRepository;

--- a/src/main/java/kr/husk/application/auth/service/UserService.java
+++ b/src/main/java/kr/husk/application/auth/service/UserService.java
@@ -13,15 +13,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final UserRepository userRepository;
 
-    public User create(String email, String password) {
-        return userRepository.save(User.builder()
-                .email(email)
-                .password(password)
-                .oAuthProvider(OAuthProvider.NONE)
-                .build());
+    public User create(User user) {
+        return userRepository.save(user);
     }
 
-    public boolean isExist(String email) {
-        return userRepository.findByEmail(email).isPresent();
+    public boolean isExist(String email, OAuthProvider oAuthProvider) {
+        return userRepository.findByEmail(email)
+                .map(user -> user.getOAuthProvider().equals(oAuthProvider))
+                .orElse(false);
     }
 }

--- a/src/main/java/kr/husk/common/entity/BaseEntity.java
+++ b/src/main/java/kr/husk/common/entity/BaseEntity.java
@@ -1,18 +1,16 @@
 package kr.husk.common.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 @SQLDelete(sql = "UPDATE #{entityName} SET deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 public class BaseEntity {

--- a/src/main/java/kr/husk/domain/auth/entity/User.java
+++ b/src/main/java/kr/husk/domain/auth/entity/User.java
@@ -7,11 +7,13 @@ import kr.husk.domain.connection.entity.Connection;
 import kr.husk.domain.keychain.entity.KeyChain;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Entity(name = "user")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
     @Column(name = "email", nullable = false, updatable = false, length = 50)

--- a/src/main/java/kr/husk/domain/auth/entity/User.java
+++ b/src/main/java/kr/husk/domain/auth/entity/User.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
 
@@ -39,5 +40,9 @@ public class User extends BaseEntity {
         this.oAuthProvider = oAuthProvider;
         this.keyChains = keyChains;
         this.connections = connections;
+    }
+
+    public void encodePassword(PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(password);
     }
 }

--- a/src/main/java/kr/husk/domain/auth/service/UserService.java
+++ b/src/main/java/kr/husk/domain/auth/service/UserService.java
@@ -1,4 +1,4 @@
-package kr.husk.application.auth.service;
+package kr.husk.domain.auth.service;
 
 import kr.husk.domain.auth.entity.User;
 import kr.husk.domain.auth.repository.UserRepository;

--- a/src/main/java/kr/husk/domain/auth/service/UserService.java
+++ b/src/main/java/kr/husk/domain/auth/service/UserService.java
@@ -1,6 +1,8 @@
 package kr.husk.domain.auth.service;
 
+import kr.husk.domain.auth.entity.User;
 import kr.husk.domain.auth.repository.UserRepository;
+import kr.husk.domain.auth.type.OAuthProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +12,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+
+    public User create(String email, String password) {
+        return userRepository.save(User.builder()
+                .email(email)
+                .password(password)
+                .oAuthProvider(OAuthProvider.NONE)
+                .build());
+    }
 
     public boolean isExist(String email) {
         return userRepository.findByEmail(email).isPresent();

--- a/src/main/java/kr/husk/infrastructure/config/AuthConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/AuthConfig.java
@@ -7,6 +7,8 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @ConfigurationProperties(prefix = "husk.auth")
@@ -19,5 +21,10 @@ public class AuthConfig {
     @Bean
     public AuthCodeRepository authCodeRepository() {
         return new ConcurrentMapAuthCodeRepository(this);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
@@ -19,6 +19,7 @@ public class SecurityConfig {
                         authorizeHttpRequests.requestMatchers(
                                         "/auth/send-code",
                                         "/auth/verify-code",
+                                        "/auth/sign-up",
                                         "/swagger-resources/**",
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,5 +37,5 @@ public interface AuthApi {
             @ApiResponse(responseCode = "200", description = "회원가입 성공"),
             @ApiResponse(responseCode = "400", description = "회원가입 실패")
     })
-    ResponseEntity<?> signUp(@RequestBody SendAuthCodeDto.Request dto);
+    ResponseEntity<?> signUp(@RequestBody SignUpDto.Request dto);
 }

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -6,13 +6,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
 import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "[인증 관련 API]", description = "사용자 인증 관련 API")
+@Validated
 public interface AuthApi {
     @Operation(summary = "인증 코드 전송", description = "이메일로 인증 코드를 전송하기 위한 API")
     @ApiResponses({
@@ -37,5 +40,5 @@ public interface AuthApi {
             @ApiResponse(responseCode = "200", description = "회원가입 성공"),
             @ApiResponse(responseCode = "400", description = "회원가입 실패")
     })
-    ResponseEntity<?> signUp(@RequestBody SignUpDto.Request dto);
+    ResponseEntity<?> signUp(@Valid @RequestBody SignUpDto.Request dto);
 }

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -30,4 +30,11 @@ public interface AuthApi {
             @ApiResponse(responseCode = "400", description = "인증 코드 검증 실패")
     })
     ResponseEntity<?> verifyAuthCode(@RequestBody VerifyAuthCodeDto.Request dto);
+
+    @Operation(summary = "일반 사용자 회원가입", description = "일반 회원가입을 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "400", description = "회원가입 실패")
+    })
+    ResponseEntity<?> signUp(@RequestBody SendAuthCodeDto.Request dto);
 }

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -1,6 +1,7 @@
 package kr.husk.presentation.rest;
 
 import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.application.auth.service.AuthService;
 import kr.husk.presentation.api.AuthApi;
@@ -26,5 +27,11 @@ public class AuthController implements AuthApi {
     @PostMapping("/verify-code")
     public ResponseEntity<?> verifyAuthCode(VerifyAuthCodeDto.Request dto) {
         return ResponseEntity.ok(authService.verifyAuthCode(dto));
+    }
+
+    @Override
+    @PostMapping("/sign-up")
+    public ResponseEntity<?> signUp(SignUpDto.Request dto) {
+        return ResponseEntity.created(null).body(authService.signUp(dto));
     }
 }

--- a/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
+++ b/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
@@ -62,7 +62,7 @@ class AuthControllerTest {
     @Test
     void signUpApiTest() throws Exception {
         // give
-        SignUpDto.Request dto = new SignUpDto.Request("jinlee1703@gmail.com", "abc123!@");
+        SignUpDto.Request dto = new SignUpDto.Request("jinlee1703@gmail.com", "Abc123!@");
 
         // when
         when(authService.signUp(dto)).thenReturn(SignUpDto.Response.of("회원가입에 성공했습니다."));

--- a/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
+++ b/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
@@ -2,6 +2,7 @@ package kr.husk.presentation.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.application.auth.service.AuthService;
 import org.junit.jupiter.api.Test;
@@ -56,5 +57,20 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void signUpApiTest() throws Exception {
+        // give
+        SignUpDto.Request dto = new SignUpDto.Request("jinlee1703@gmail.com", "abc123!@");
+
+        // when
+        when(authService.signUp(dto)).thenReturn(SignUpDto.Response.of("회원가입에 성공했습니다."));
+
+        // then
+        mockMvc.perform(post("/auth/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated());
     }
 }


### PR DESCRIPTION
## Motivation

- [HK-41 | [BE] 회원 가입 API 구현](https://team-dopamine.atlassian.net/browse/HK-41?atlOrigin=eyJpIjoiNGEzOTdkYmJlMzg0NDBkZjg3NTYxZDU5MmNhZGY4NDAiLCJwIjoiaiJ9)
- 서비스 이용을 위한 일반 사용자(Third-Party Platform 회원이 아닌)의 회원가입 기능 제공 필요성 대두

## Problem Solving

- 사용자 생성 로직 구현
  - 기본적으로는 `OAuthProvider.NONE`으로 저장되도록 구현 (b5e5e33b7cade89ff8dcad2674dbcade459e604e)
- 회원가입 Usecase 로직 구현
  - 비밀번호 형식(대/소문자 8~16글자, 숫자 및 특수문자 포함) 적용 (1b32dcb535a52a5522ea135f2ce66f7497337c89)
  - 비밀번호 단방향 암호화 적용 (926e397dade748d564a86a8b13a580a6cc994e16)
- 회원가입 API CSRF 허용 (e7ebb9a7a90895de401dff3055cf34fdb9fc5d14)
- `PropertyValueException` 이슈 해결 (71d28dfa62699c33173906491efcd8b373ca262b)

## To Reviewer

### `PropertyValueException` 이슈?
  
```plaintext
org.hibernate.PropertyValueException: not-null property references a null or transient value : kr.husk.domain.auth.entity.User.createdAt
at org.hibernate.engine.internal.Nullability.checkNullability(Nullability.java:109) ~[hibernate-core-6.5.3.Final.jar:6.5.3.Final]
at org.hibernate.engine.internal.Nullability.checkNullability(Nullability.java:54) ~[hibernate-core-6.5.3.Final.jar:6.5.3.Final]
```

- JPA Auditing이 올바르게 동작하지 않아서 발생하는 이슈
  - `@CreatedDate`와 같은 어노테이션이 동작하지 않아, not-null 컬럼에 값이 저장되지 않음
- 해결 방법은 commit 참고 (71d28dfa62699c33173906491efcd8b373ca262b)

[HK-41]: https://team-dopamine.atlassian.net/browse/HK-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ