### PR TITLE
chore/HK-42: 공통 예외 처리를 위한 Custom Exception 구현

### DIFF
--- a/src/main/java/kr/husk/common/exception/ExceptionCode.java
+++ b/src/main/java/kr/husk/common/exception/ExceptionCode.java
@@ -1,0 +1,9 @@
+package kr.husk.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionCode {
+    public HttpStatus getHttpStatus();
+    public String getCause();
+    public String getName();
+}

--- a/src/main/java/kr/husk/common/exception/ExceptionResponse.java
+++ b/src/main/java/kr/husk/common/exception/ExceptionResponse.java
@@ -1,0 +1,22 @@
+package kr.husk.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ExceptionResponse {
+    private LocalDateTime timeStamp;
+    private String name;
+    private String cause;
+
+    public static ExceptionResponse of(ExceptionCode exceptionCode) {
+        return ExceptionResponse.builder()
+                .timeStamp(LocalDateTime.now())
+                .name(exceptionCode.getName())
+                .cause(exceptionCode.getCause())
+                .build();
+    }
+}

--- a/src/main/java/kr/husk/common/exception/GlobalException.java
+++ b/src/main/java/kr/husk/common/exception/GlobalException.java
@@ -1,0 +1,14 @@
+package kr.husk.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GlobalException extends RuntimeException {
+    ExceptionCode exceptionCode;
+
+    public GlobalException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getCause());
+        this.exceptionCode = exceptionCode;
+    }
+
+}

--- a/src/main/java/kr/husk/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/husk/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package kr.husk.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ExceptionResponse> handler(GlobalException e) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        ExceptionResponse response = ExceptionResponse.of(exceptionCode);
+        log.error("[GlobalException] name:" + e.getExceptionCode().getName() + ", cause: " + e.getExceptionCode().getCause());
+        return ResponseEntity.status(exceptionCode.getHttpStatus()).body(response);
+    }
+
+}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 각 도메인별 API에 대한 예외 처리 일원화
- 예외 전달 시 좀 더 상세하고 명시적인 정보 제공 필요
- 예외 발생 후 처리 작업성 향상을 위함                                                                                 

## Problem Solving

<!-- 해결 방법 -->
- `Custom Exception` 구현
  - `GlobalException`, `GlobalExceptionHandler`, `ExceptionCode`, `ExceptionResponse`를 구현하여 예외 처리를 일원화 함.
  - 예외 발생 시 Custom Exception에서 해당 예외를 catch하여 커스터마이징 된 예외를 발생시키도록 함.
  - 참고: https://mangkyu.tistory.com/204 https://mangkyu.tistory.com/205
  - (위 블로그의 글이 잘 설명되어 있어서 별도로 SpringBoot에서 예외 처리하는 로직 공부하실 때 도움이 되실 것 같아요!)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
![image](https://github.com/user-attachments/assets/d62c1ef4-e8d6-499a-8056-04f3bf619ee2)
- 위 사진은 이메일 인증 코드 실패 시 Custom Exception으로 처리된 것 입니다. 

- 기존의 예외는 별도의 PR로 분리하려고 합니다! 추후 PR 올리도록 하겠습니다
- 제가 전에 사용했던 방식으로 구현했는데, 혹시 추가적으로 피드백 주신다면 수정하겠습니다!