### PR TITLE
Feature(HK-73): Global Exception 구현 및 적용

### DIFF
--- a/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
@@ -1,0 +1,32 @@
+package kr.husk.domain.auth.exception;
+
+import kr.husk.common.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+public enum AuthExceptionCode implements ExceptionCode {
+    VERIFICATION_CODE_NOT_MATCH(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 메일 발송에 실패했습니다.");
+
+    HttpStatus httpStatus;
+    String cause;
+
+    AuthExceptionCode(HttpStatus httpStatus, String cause) {
+        this.httpStatus = httpStatus;
+        this.cause = cause;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCause() {
+        return cause;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/src/main/java/kr/husk/domain/auth/exception/UserExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/UserExceptionCode.java
@@ -1,0 +1,32 @@
+package kr.husk.domain.auth.exception;
+
+import kr.husk.common.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+public enum UserExceptionCode implements ExceptionCode {
+
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다.");
+
+    HttpStatus httpStatus;
+    String cause;
+
+    UserExceptionCode(org.springframework.http.HttpStatus httpStatus, String cause) {
+        this.httpStatus = httpStatus;
+        this.cause = cause;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCause() {
+        return cause;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 이전 작업으로 공통 예외 처리를 위해 Custom Exception을 구현(https://github.com/team-dopamine/husk-was/pull/13)
- 기존에 만들어진 API(이메일 전송, 인증,  회원가입)에 Custom Exception 적용을 위한 Global Exception 적용
## Problem Solving

<!-- 해결 방법 -->
- User 관련 예외 코드 추가 (7da6e08819aa2f2aa10716e0e3b9693b91f0cd69)
- Auth 관련 예외 코드 추가 (e24c4ef1b4ac9cf423691067f208b665de8a6ac4)
- AuthService에 위의 예외 코드 적용 (c77114ada5e661001eb598e15358ef8ae39b0ec1)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

![global exception 적용](https://github.com/user-attachments/assets/a75e1972-0f71-430e-ba3b-50e5390546a9)

위 이미지는 Custom Exception PR에 있지만, 본 PR의 적용 사항이라 여기에도 올려놓겠습니다!
우선은 구현된 API에 대해서만 예외 코드를 만들어 적용해놓았습니다. 추후에 개발되는 API에는 작업자가 예외 코드를 별도로 만들고 PR을 통해서 네이밍, 에러 코드 등을 이야기 해보면 좋을 것 같습니다!