### PR TITLE
Feature(HK-74): 서비스 일반 계정 로그인을 위한 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,12 @@ dependencies {
     implementation(platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.2.0"))
     implementation("io.awspring.cloud:spring-cloud-aws-starter")
     implementation("io.awspring.cloud:spring-cloud-aws-starter-parameter-store")
+
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-orgjson', version: '0.11.2'
+    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.30.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/husk/application/auth/dto/JwtTokenDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/JwtTokenDto.java
@@ -1,0 +1,14 @@
+package kr.husk.application.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class JwtTokenDto {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/kr/husk/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SignInDto.java
@@ -1,0 +1,33 @@
+package kr.husk.application.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SignInDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "SignIn.Request", description = "로그인 요청 DTO")
+    public static class Request {
+
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        private String email;
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        private String password;
+
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "SignIn.Request", description = "로그인 요청 DTO")
+    public static class Response {
+        private String message;
+        private JwtTokenDto jwtTokenDto;
+    }
+}

--- a/src/main/java/kr/husk/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SignInDto.java
@@ -3,6 +3,7 @@ package kr.husk.application.auth.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,9 +17,13 @@ public class SignInDto {
     public static class Request {
 
         @NotBlank(message = "이메일은 필수 입력값입니다.")
-        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Email(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+                message = "올바른 이메일 형식이 아닙니다.")
         private String email;
+
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()-_=+]).{8,16}$",
+                message = "비밀번호는 8자 이상 16자 이하이며, 숫자, 소문자, 대문자, 특수문자를 포함해야 합니다.")
         private String password;
 
     }

--- a/src/main/java/kr/husk/application/auth/dto/SignUpDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SignUpDto.java
@@ -18,7 +18,8 @@ public class SignUpDto {
     @Schema(name = "SignUp.Request", description = "회원가입 요청 DTO")
     public static class Request {
         @NotBlank(message = "이메일은 필수 입력값입니다.")
-        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Email(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+                message = "올바른 이메일 형식이 아닙니다.")
         @Schema(description = "이메일", example = "team.dopamine.dev@gmail.com")
         private String email;
 

--- a/src/main/java/kr/husk/common/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/husk/common/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package kr.husk.common.jwt.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.husk.common.jwt.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = jwtProvider.resolveToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            String email = jwtProvider.getEmail(token.split(" ")[1].trim());
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    email, null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/kr/husk/common/jwt/util/JwtProvider.java
+++ b/src/main/java/kr/husk/common/jwt/util/JwtProvider.java
@@ -1,0 +1,77 @@
+package kr.husk.common.jwt.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final String secret;
+    private final long refreshExpiration;
+    private final long accessExpiration;
+    private final String issuer;
+
+    public JwtProvider(@Value("${jwt.secret}") String secret,
+                       @Value("${jwt.access-expiration}") long accessExpiration,
+                       @Value("${jwt.refresh-expiration}") long refreshExpiration,
+                       @Value("${jwt.issuer}") String issuer) {
+        this.secret = secret;
+        this.accessExpiration = accessExpiration;
+        this.refreshExpiration = refreshExpiration;
+        this.issuer = issuer;
+    }
+
+    public String generateToken(String email, long expiration) {
+        Claims claims = Jwts.claims();
+        claims.setSubject(email);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(SignatureAlgorithm.HS512, secret.getBytes())
+                .compact();
+    }
+
+    public String generateAccessToken(String email) {
+        return generateToken(email, accessExpiration);
+    }
+
+    public String generateRefreshToken(String email) {
+        return generateToken(email, refreshExpiration);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            if (!token.substring(0, "Bearer ".length()).equalsIgnoreCase("Bearer ")) {
+                return false;
+            } else {
+                token = token.split(" ")[1].trim();
+            }
+            Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(secret.getBytes()).build().parseClaimsJws(token);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        return request.getHeader("Authorization");
+    }
+
+    public String getEmail(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secret.getBytes())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/src/main/java/kr/husk/common/jwt/util/JwtProvider.java
+++ b/src/main/java/kr/husk/common/jwt/util/JwtProvider.java
@@ -34,6 +34,7 @@ public class JwtProvider {
 
         return Jwts.builder()
                 .setClaims(claims)
+                .setIssuer(issuer)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + expiration))
                 .signWith(SignatureAlgorithm.HS512, secret.getBytes())
@@ -50,7 +51,7 @@ public class JwtProvider {
 
     public boolean validateToken(String token) {
         try {
-            if (!token.substring(0, "Bearer ".length()).equalsIgnoreCase("Bearer ")) {
+            if (!token.startsWith("Bearer ")) {
                 return false;
             } else {
                 token = token.split(" ")[1].trim();

--- a/src/main/java/kr/husk/domain/auth/entity/User.java
+++ b/src/main/java/kr/husk/domain/auth/entity/User.java
@@ -1,6 +1,10 @@
 package kr.husk.domain.auth.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToMany;
 import kr.husk.common.entity.BaseEntity;
 import kr.husk.domain.auth.type.OAuthProvider;
 import kr.husk.domain.connection.entity.Connection;
@@ -44,5 +48,9 @@ public class User extends BaseEntity {
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(password);
+    }
+
+    public boolean isMatched(PasswordEncoder passwordEncoder, String password) {
+        return passwordEncoder.matches(password, this.password);
     }
 }

--- a/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum AuthExceptionCode implements ExceptionCode {
     VERIFICATION_CODE_NOT_MATCH(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
-    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 메일 발송에 실패했습니다.");
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 메일 발송에 실패했습니다."),
+    PASSWORD_MISMATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/kr/husk/domain/auth/exception/UserExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/UserExceptionCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum UserExceptionCode implements ExceptionCode {
 
-    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다.");
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
+    EMAIL_IS_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다.");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/kr/husk/domain/auth/service/UserService.java
+++ b/src/main/java/kr/husk/domain/auth/service/UserService.java
@@ -1,6 +1,8 @@
 package kr.husk.domain.auth.service;
 
+import kr.husk.common.exception.GlobalException;
 import kr.husk.domain.auth.entity.User;
+import kr.husk.domain.auth.exception.UserExceptionCode;
 import kr.husk.domain.auth.repository.UserRepository;
 import kr.husk.domain.auth.type.OAuthProvider;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,12 @@ public class UserService {
 
     public User create(User user) {
         return userRepository.save(user);
+    }
+
+    public User read(String email, OAuthProvider oAuthProvider) {
+        return userRepository.findByEmail(email)
+                .filter(user -> user.getOAuthProvider().equals(oAuthProvider))
+                .orElseThrow(() -> new GlobalException(UserExceptionCode.EMAIL_IS_NOT_FOUND));
     }
 
     public boolean isExist(String email, OAuthProvider oAuthProvider) {

--- a/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package kr.husk.infrastructure.config;
 
+import kr.husk.common.jwt.filter.JwtAuthenticationFilter;
+import kr.husk.common.jwt.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -7,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -17,6 +20,8 @@ import java.util.Arrays;
 @EnableWebSecurity(debug = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
 
     @Value("${cors.allowed-origins}")
     private String allowedOrigins;
@@ -31,13 +36,15 @@ public class SecurityConfig {
                                         "/auth/send-code",
                                         "/auth/verify-code",
                                         "/auth/sign-up",
+                                        "/auth/sign-in",
                                         "/auth/terms-of-service",
                                         "/swagger-resources/**",
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",
                                         "/webjars/**",
                                         "/error").permitAll()
-                                .anyRequest().authenticated());
+                                .anyRequest().authenticated())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
 
         return httpSecurity.build();
     }

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.SignInDto;
 import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import org.springframework.http.ResponseEntity;
@@ -48,4 +49,11 @@ public interface AuthApi {
             @ApiResponse(responseCode = "400", description = "약관 조회 실패")
     })
     ResponseEntity<?> getTermsOfService();
+
+    @Operation(summary = "일반 사용자 로그인", description = "일반 로그인을 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "로그인 실패")
+    })
+    ResponseEntity<?> signIn(@Valid @RequestBody SignInDto.Request dto);
 }

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -1,6 +1,7 @@
 package kr.husk.presentation.rest;
 
 import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.SignInDto;
 import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.application.auth.service.AuthService;
@@ -40,5 +41,11 @@ public class AuthController implements AuthApi {
     @GetMapping("/terms-of-service")
     public ResponseEntity<?> getTermsOfService() {
         return ResponseEntity.ok(authService.readTermsOfService());
+    }
+
+    @Override
+    @PostMapping("/sign-in")
+    public ResponseEntity<?> signIn(SignInDto.Request dto) {
+        return ResponseEntity.ok(authService.signIn(dto));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,9 @@ aws:
 
 cors:
   allowed-origins: ${cors.allowed-origins}
+
+jwt:
+  secret: ${jwt.secret}
+  access-expiration: ${jwt.access-expiration}
+  refresh-expiration: ${jwt.refresh-expiration}
+  issuer: ${jwt.issuer}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- [HK-74](https://team-dopamine.atlassian.net/browse/HK-74?atlOrigin=eyJpIjoiYjc5NGE2YmZiZmI3NGQ5NWIzMWNjMDBlZGIxYzNhY2MiLCJwIjoiaiJ9)
- OAuth가 아닌 일반 계정에 대한 로그인 기능 필요

## Problem Solving

<!-- 해결 방법 -->
- JWT 기반 인증 방식 선정. 
  - `JwtAuthenticationFilter`, `JwtProvider` 객체 구현
  - `/auth/sign-in` end point 접근 허용
  - `access token`, `refresh token`을 활용하여 인증 비즈니스 로직 구현
  - Jwt 관련 환경 변수 AWS Parameter Store 등록
- 일반 로그인 API 구현

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->

<details>
<summary>API 테스트 결과</summary>

![image](https://github.com/user-attachments/assets/1f2b38ac-8c48-4c8a-837c-55038350e2cf)
</details>

- JWT 관련 환경변수는 `Parameter Store`에 등록되어 있습니다!
- 일반 로그인 API 구현이 거의 처음이라 최대한 여러 자료를 보면서 구현했지만, 부족한 부분이 많을 것이라 예상됩니다! 그런 부분은 코멘트 남겨주시면 감사하겠습니다!
- `UserDetails`, `UserDetailsService`, `AuthenticationProvider` 등을 별도로 구현하지는 않았는데 문제가 되지는 않는지 궁금합니다.

[HK-74]: https://team-dopamine.atlassian.net/browse/HK-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ