### PR TITLE
Feature(HK-83): JWT 인증 관련 Refresh Token 로직 추가

### DIFF
--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -14,7 +14,7 @@ import kr.husk.domain.auth.repository.AuthCodeRepository;
 import kr.husk.domain.auth.service.UserService;
 import kr.husk.domain.auth.type.OAuthProvider;
 import kr.husk.infrastructure.config.AuthConfig;
-import kr.husk.infrastructure.persistence.ConcurrentMapRefreshRefreshTokenRepository;
+import kr.husk.infrastructure.persistence.ConcurrentMapRefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.SimpleMailMessage;
@@ -33,7 +33,7 @@ public class AuthService {
     private final UserService userService;
     private final AuthCodeRepository authCodeRepository;
     private final JwtProvider jwtProvider;
-    private final ConcurrentMapRefreshRefreshTokenRepository concurrentMapRefreshTokenRepository;
+    private final ConcurrentMapRefreshTokenRepository concurrentMapRefreshTokenRepository;
 
     @Transactional
     public SendAuthCodeDto.Response sendAuthCode(SendAuthCodeDto.Request dto) {
@@ -88,14 +88,14 @@ public class AuthService {
         }
 
         String accessToken = jwtProvider.generateAccessToken(user.getEmail());
-        String refreshToken = jwtProvider.generateRefreshToken(user.getEmail());
+        concurrentMapRefreshTokenRepository.create(user.getEmail());
+        String refreshToken = concurrentMapRefreshTokenRepository.read(user.getEmail()).get();
+
         JwtTokenDto tokenDto = JwtTokenDto.builder()
                 .grantType("Bearer ")
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
-
-        concurrentMapRefreshTokenRepository.create(user.getEmail(), refreshToken);
 
         log.info("로그인에 성공하였습니다. 이메일: {}", dto.getEmail());
         return new SignInDto.Response("로그인에 성공하였습니다.", tokenDto);

--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import kr.husk.domain.auth.repository.AuthCodeRepository;
 import kr.husk.domain.auth.service.UserService;
 import kr.husk.domain.auth.type.OAuthProvider;
 import kr.husk.infrastructure.config.AuthConfig;
+import kr.husk.infrastructure.persistence.ConcurrentMapRefreshRefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.SimpleMailMessage;
@@ -32,6 +33,7 @@ public class AuthService {
     private final UserService userService;
     private final AuthCodeRepository authCodeRepository;
     private final JwtProvider jwtProvider;
+    private final ConcurrentMapRefreshRefreshTokenRepository concurrentMapRefreshTokenRepository;
 
     @Transactional
     public SendAuthCodeDto.Response sendAuthCode(SendAuthCodeDto.Request dto) {
@@ -92,6 +94,8 @@ public class AuthService {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
+
+        concurrentMapRefreshTokenRepository.create(user.getEmail(), refreshToken);
 
         log.info("로그인에 성공하였습니다. 이메일: {}", dto.getEmail());
         return new SignInDto.Response("로그인에 성공하였습니다.", tokenDto);

--- a/src/main/java/kr/husk/common/jwt/util/JwtProvider.java
+++ b/src/main/java/kr/husk/common/jwt/util/JwtProvider.java
@@ -78,7 +78,7 @@ public class JwtProvider {
 
     public long getExpirationTime(String token) {
         return Jwts.parserBuilder()
-                .setSigningKey(secret)
+                .setSigningKey(secret.getBytes())
                 .build()
                 .parseClaimsJws(token)
                 .getBody()

--- a/src/main/java/kr/husk/common/jwt/util/JwtProvider.java
+++ b/src/main/java/kr/husk/common/jwt/util/JwtProvider.java
@@ -75,4 +75,14 @@ public class JwtProvider {
                 .getBody()
                 .getSubject();
     }
+
+    public long getExpirationTime(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secret)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration()
+                .getTime();
+    }
 }

--- a/src/main/java/kr/husk/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/kr/husk/domain/auth/repository/RefreshTokenRepository.java
@@ -3,7 +3,7 @@ package kr.husk.domain.auth.repository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository {
-    void create(String email, String token);
+    void create(String email);
 
     Optional<String> read(String email);
 

--- a/src/main/java/kr/husk/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/kr/husk/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package kr.husk.domain.auth.repository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+    void create(String email, String token);
+
+    Optional<String> read(String email);
+
+    void delete(String email);
+}

--- a/src/main/java/kr/husk/infrastructure/persistence/ConcurrentMapRefreshRefreshTokenRepository.java
+++ b/src/main/java/kr/husk/infrastructure/persistence/ConcurrentMapRefreshRefreshTokenRepository.java
@@ -1,0 +1,53 @@
+package kr.husk.infrastructure.persistence;
+
+import kr.husk.common.jwt.util.JwtProvider;
+import kr.husk.domain.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class ConcurrentMapRefreshRefreshTokenRepository implements RefreshTokenRepository {
+
+    private final JwtProvider jwtProvider;
+    private final ConcurrentHashMap<String, String> refreshTokenMap = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+
+    @Override
+    public void create(String email, String token) {
+        refreshTokenMap.put(email, token);
+
+        long expirationInMillis = jwtProvider.getExpirationTime(token);
+        long delayInMillis = expirationInMillis - System.currentTimeMillis();
+
+        scheduledExecutorService.schedule(() -> refreshTokenMap.remove(email), delayInMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public Optional<String> read(String email) {
+        String refreshToken = refreshTokenMap.get(email);
+
+        if (refreshToken == null) {
+            return Optional.empty();
+        }
+
+        if (jwtProvider.validateToken(refreshToken)) {
+            refreshTokenMap.remove(email);
+            return Optional.empty();
+        }
+
+        return Optional.of(refreshToken);
+    }
+
+    @Override
+    public void delete(String email) {
+        refreshTokenMap.remove(email);
+    }
+
+}

--- a/src/main/java/kr/husk/infrastructure/persistence/ConcurrentMapRefreshTokenRepository.java
+++ b/src/main/java/kr/husk/infrastructure/persistence/ConcurrentMapRefreshTokenRepository.java
@@ -13,17 +13,18 @@ import java.util.concurrent.TimeUnit;
 
 @Repository
 @RequiredArgsConstructor
-public class ConcurrentMapRefreshRefreshTokenRepository implements RefreshTokenRepository {
+public class ConcurrentMapRefreshTokenRepository implements RefreshTokenRepository {
 
     private final JwtProvider jwtProvider;
     private final ConcurrentHashMap<String, String> refreshTokenMap = new ConcurrentHashMap<>();
     private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
     @Override
-    public void create(String email, String token) {
-        refreshTokenMap.put(email, token);
+    public void create(String email) {
+        String refreshToken = jwtProvider.generateRefreshToken(email);
+        refreshTokenMap.put(email, refreshToken);
 
-        long expirationInMillis = jwtProvider.getExpirationTime(token);
+        long expirationInMillis = jwtProvider.getExpirationTime(refreshToken);
         long delayInMillis = expirationInMillis - System.currentTimeMillis();
 
         scheduledExecutorService.schedule(() -> refreshTokenMap.remove(email), delayInMillis, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- [Jira(HK-83)](https://team-dopamine.atlassian.net/browse/HK-83?atlOrigin=eyJpIjoiZWNkNmY5OGQ1YWQ3NDI2YWI3NGFhMzA2ODEyODQzYjciLCJwIjoiaiJ9)
- JWT를 활용한 인증 방식을 채택하여 Sign-In API 구현 (#17)
- JWT의 Refresh Token을 관리하는 관련 로직 필요

## Problem Solving

<!-- 해결 방법 -->
- `AuthCode`와 같이 `ConcurrentHashMap` 자료구조를 사용하여 일반 이메일 계정에 따른 refresh token 관리
- `refresh token` 생성, 조회, 삭제 관련 기능 구현
- `Sign-In` 진행 시 `access token`과 `refresh token` 생성 후 `ConcurrentHashMap`에 `refresh token 저장`
- `refresh token`을 `ConcurrentHashMap`에 저장한 후 스케줄링을 통해 만료시간이 되면 자동으로 `refresh token` 삭제

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- `AuthService`의 `signIn` 진행 시 기존에 저장된 `refresh token`이 존재하는지 확인하는 메소드가 필요한지 궁금하네요!
  - 추후 `signOut` API 개발 시 `refresh token`을 삭제하도록록 구현할 예정인데 그럼에도 확인이 필요한지 궁금합니다!