### PR TITLE
Feature(HK-75): Google OAuth 로그인 기능 구현

### DIFF
--- a/src/main/java/kr/husk/application/auth/config/GoogleConfig.java
+++ b/src/main/java/kr/husk/application/auth/config/GoogleConfig.java
@@ -1,0 +1,17 @@
+package kr.husk.application.auth.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "oauth2.google")
+public class GoogleConfig {
+    private String clientId;
+    private String clientSecret;
+    private String scope;
+    private String redirectUri;
+    private String tokenUri;
+    private String userInfoUri;
+}

--- a/src/main/java/kr/husk/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SignInDto.java
@@ -30,7 +30,7 @@ public class SignInDto {
 
     @Getter
     @AllArgsConstructor
-    @Schema(name = "SignIn.Request", description = "로그인 요청 DTO")
+    @Schema(name = "SignIn.Response", description = "로그인 응답 DTO")
     public static class Response {
         private String message;
         private JwtTokenDto jwtTokenDto;

--- a/src/main/java/kr/husk/application/auth/service/GoogleOAuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/GoogleOAuthService.java
@@ -1,0 +1,100 @@
+package kr.husk.application.auth.service;
+
+import kr.husk.application.auth.config.GoogleConfig;
+import kr.husk.application.auth.dto.JwtTokenDto;
+import kr.husk.application.auth.dto.SignInDto;
+import kr.husk.common.exception.GlobalException;
+import kr.husk.common.jwt.util.JwtProvider;
+import kr.husk.domain.auth.entity.User;
+import kr.husk.domain.auth.exception.AuthExceptionCode;
+import kr.husk.domain.auth.service.UserService;
+import kr.husk.domain.auth.type.OAuthProvider;
+import kr.husk.infrastructure.persistence.ConcurrentMapRefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuthService {
+
+    private final UserService userService;
+    private final JwtProvider jwtProvider;
+    private final GoogleConfig googleConfig;
+    private final ConcurrentMapRefreshTokenRepository concurrentMapRefreshTokenRepository;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public ResponseEntity<SignInDto.Response> googleSignIn(@RequestParam("code") String code) {
+        String token = getToken(code);
+        Map<String, Object> userInfo = getGoogleUserInfo(token);
+        String email = (String) userInfo.get("email");
+
+        if (!userService.isExist(email, OAuthProvider.GOOGLE)) {
+            User user = User.builder()
+                    .email(email)
+                    .password(null)
+                    .oAuthProvider(OAuthProvider.GOOGLE)
+                    .build();
+
+            userService.create(user);
+        }
+
+        String accessToken = jwtProvider.generateAccessToken(email);
+        concurrentMapRefreshTokenRepository.create(email);
+        String refreshToken = concurrentMapRefreshTokenRepository.read(email).get();
+
+        JwtTokenDto tokenDto = JwtTokenDto.builder()
+                .grantType("Bearer ")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        SignInDto.Response response = new SignInDto.Response("Google OAuth 로그인 성공", tokenDto);
+
+        log.info("OAuth Google 로그인에 성공하였습니다. 이메일: {}", email);
+        return ResponseEntity.ok(response);
+    }
+
+    public String getToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", googleConfig.getClientId());
+        params.add("client_secret", googleConfig.getClientSecret());
+        params.add("redirect_uri", googleConfig.getRedirectUri());
+        params.add("code", code);
+
+        Map<String, Object> response = restTemplate.postForObject(googleConfig.getTokenUri(), params, Map.class);
+
+        if (response != null && response.containsKey("access_token")) {
+            return (String) response.get("access_token");
+        } else {
+            throw new GlobalException(AuthExceptionCode.ACCESSTOKEN_REQUEST_FAILED);
+        }
+
+    }
+
+    private Map<String, Object> getGoogleUserInfo(String accessToken) {
+        String userInfoUrl = googleConfig.getUserInfoUri() + "?access_token=" + accessToken;
+
+        Map<String, Object> userInfoResponse = restTemplate.getForObject(userInfoUrl, Map.class);
+
+        if (userInfoResponse != null) {
+            return userInfoResponse;
+        } else {
+            throw new GlobalException(AuthExceptionCode.GOOGLE_USERINFO_NOTFOUND);
+        }
+    }
+}

--- a/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
@@ -8,8 +8,8 @@ public enum AuthExceptionCode implements ExceptionCode {
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 메일 발송에 실패했습니다."),
     PASSWORD_MISMATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     GOOGLE_USERINFO_NOTFOUND(HttpStatus.NOT_FOUND, "Google 사용자 정보 요청에 실패했습니다."),
-    ACCESSTOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "Google OAuth Access Token 요청에 실패했습니다.");
-
+    ACCESSTOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "Google OAuth Access Token 요청에 실패했습니다."),
+    NOT_ALLOWED_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "허용되지 않은 OAuth 타입 요청입니다.");
     HttpStatus httpStatus;
     String cause;
 

--- a/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
@@ -6,7 +6,9 @@ import org.springframework.http.HttpStatus;
 public enum AuthExceptionCode implements ExceptionCode {
     VERIFICATION_CODE_NOT_MATCH(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 메일 발송에 실패했습니다."),
-    PASSWORD_MISMATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+    PASSWORD_MISMATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    GOOGLE_USERINFO_NOTFOUND(HttpStatus.NOT_FOUND, "Google 사용자 정보 요청에 실패했습니다."),
+    ACCESSTOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "Google OAuth Access Token 요청에 실패했습니다.");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/kr/husk/domain/auth/repository/UserRepository.java
+++ b/src/main/java/kr/husk/domain/auth/repository/UserRepository.java
@@ -1,10 +1,16 @@
 package kr.husk.domain.auth.repository;
 
 import kr.husk.domain.auth.entity.User;
+import kr.husk.domain.auth.type.OAuthProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    @Query("SELECT u FROM user u WHERE u.email = :email And u.oAuthProvider = :oAuthProvider")
+    Optional<User> findByEmailAndOAuthProvider(String email, OAuthProvider oAuthProvider);
+
 }

--- a/src/main/java/kr/husk/domain/auth/repository/UserRepository.java
+++ b/src/main/java/kr/husk/domain/auth/repository/UserRepository.java
@@ -8,8 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
-
     @Query("SELECT u FROM user u WHERE u.email = :email And u.oAuthProvider = :oAuthProvider")
     Optional<User> findByEmailAndOAuthProvider(String email, OAuthProvider oAuthProvider);
 

--- a/src/main/java/kr/husk/domain/auth/service/UserService.java
+++ b/src/main/java/kr/husk/domain/auth/service/UserService.java
@@ -20,8 +20,7 @@ public class UserService {
     }
 
     public User read(String email, OAuthProvider oAuthProvider) {
-        return userRepository.findByEmail(email)
-                .filter(user -> user.getOAuthProvider().equals(oAuthProvider))
+        return userRepository.findByEmailAndOAuthProvider(email, oAuthProvider)
                 .orElseThrow(() -> new GlobalException(UserExceptionCode.EMAIL_IS_NOT_FOUND));
     }
 

--- a/src/main/java/kr/husk/domain/auth/service/UserService.java
+++ b/src/main/java/kr/husk/domain/auth/service/UserService.java
@@ -26,8 +26,6 @@ public class UserService {
     }
 
     public boolean isExist(String email, OAuthProvider oAuthProvider) {
-        return userRepository.findByEmail(email)
-                .map(user -> user.getOAuthProvider().equals(oAuthProvider))
-                .orElse(false);
+        return userRepository.findByEmailAndOAuthProvider(email, oAuthProvider).isPresent();
     }
 }

--- a/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                                         "/auth/verify-code",
                                         "/auth/sign-up",
                                         "/auth/sign-in",
+                                        "/auth/sign-in/google",
                                         "/auth/terms-of-service",
                                         "/swagger-resources/**",
                                         "/swagger-ui/**",

--- a/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
@@ -37,7 +37,6 @@ public class SecurityConfig {
                                         "/auth/verify-code",
                                         "/auth/sign-up",
                                         "/auth/sign-in",
-                                        "/auth/sign-in/google",
                                         "/auth/terms-of-service",
                                         "/swagger-resources/**",
                                         "/swagger-ui/**",

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -14,6 +14,7 @@ import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "[인증 관련 API]", description = "사용자 인증 관련 API")
 @Validated
@@ -56,4 +57,11 @@ public interface AuthApi {
             @ApiResponse(responseCode = "400", description = "로그인 실패")
     })
     ResponseEntity<?> signIn(@Valid @RequestBody SignInDto.Request dto);
+
+    @Operation(summary = "Google OAuth 로그인", description = "Google OAuth 로그인을 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "400", description = "로그인 실패")
+    })
+    ResponseEntity<?> signIn(@RequestParam("code") String code);
 }

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -63,5 +63,5 @@ public interface AuthApi {
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
             @ApiResponse(responseCode = "400", description = "로그인 실패")
     })
-    ResponseEntity<?> signIn(@RequestParam("code") String code);
+    ResponseEntity<?> signIn(@RequestParam("type") String type, @RequestParam("code") String code);
 }

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -5,12 +5,14 @@ import kr.husk.application.auth.dto.SignInDto;
 import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.application.auth.service.AuthService;
+import kr.husk.application.auth.service.GoogleOAuthService;
 import kr.husk.presentation.api.AuthApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController implements AuthApi {
     private final AuthService authService;
+    private final GoogleOAuthService googleOAuthService;
 
     @Override
     @PostMapping("/send-code")
@@ -47,5 +50,11 @@ public class AuthController implements AuthApi {
     @PostMapping("/sign-in")
     public ResponseEntity<?> signIn(SignInDto.Request dto) {
         return ResponseEntity.ok(authService.signIn(dto));
+    }
+
+    @Override
+    @GetMapping("/sign-in/google")
+    public ResponseEntity<?> signIn(@RequestParam("code") String code) {
+        return ResponseEntity.ok(googleOAuthService.googleSignIn(code));
     }
 }

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -6,6 +6,8 @@ import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.application.auth.service.AuthService;
 import kr.husk.application.auth.service.GoogleOAuthService;
+import kr.husk.common.exception.GlobalException;
+import kr.husk.domain.auth.exception.AuthExceptionCode;
 import kr.husk.presentation.api.AuthApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -53,8 +55,12 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    @GetMapping("/sign-in/google")
-    public ResponseEntity<?> signIn(@RequestParam("code") String code) {
-        return ResponseEntity.ok(googleOAuthService.googleSignIn(code));
+    @GetMapping("/sign-in")
+    public ResponseEntity<?> signIn(@RequestParam("type") String type, @RequestParam("code") String code) {
+        if ("google".equals(type)) {
+            return ResponseEntity.ok(googleOAuthService.googleSignIn(code));
+        } else {
+            throw new GlobalException(AuthExceptionCode.NOT_ALLOWED_TYPE);
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,3 +44,12 @@ jwt:
   access-expiration: ${jwt.access-expiration}
   refresh-expiration: ${jwt.refresh-expiration}
   issuer: ${jwt.issuer}
+
+oauth2:
+  google:
+    client-id: ${oauth2.google.client-id}
+    client-secret: ${oauth2.google.client-secret}
+    scope: ${oauth2.google.scope}
+    redirect-uri: ${oauth2.google.redirect-uri}
+    token-uri: ${oauth2.google.token-uri}
+    user-info-uri: ${oauth2.google.user-info-uri}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- [HK-75](https://team-dopamine.atlassian.net/browse/HK-75?atlOrigin=eyJpIjoiNGQ2NWViNmQ0MzRjNDA0NzgxNzZhYzRlN2ZiYzE0Y2UiLCJwIjoiaiJ9)
- 편리한 서비스 이용을 위한 `Google OAuth2.0` 로그인 구현

## Problem Solving

<!-- 해결 방법 -->
- 팀 계정으로 Google OAuth 프로젝트 등록 및 클라이언트 ID, Secret 발급.
- `auth/sign-in/google` Endpoint 등록.
- `Google`로부터 발급받은 액세스 토큰 확인 후 `WAS`에서 액세스 토큰 및 리프레시 토큰 발행

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- OAuth로 로그인하는 이메일과 일반 회원가입을 통해 가입된 이메일이 중복되는 경우 기존의 `UserService`의 `isExist()` 메소드를 사용하는 경우 오류 발생.
- `UserRepository`에서 `findByEmailAndOAuthProvider()` 메소드로 이메일 존재 여부를 확인하는데 이 부분에서 JPA에서 메소드명에 따른 쿼리를 생성하는 부분에서도 문제가 생겨 `@Query`을 사용하여 처리하도록 수정 및 구현하였습니다.(038c5adf95970a382d14fe381671be0882aad157)
- 해당 오류에 대한 처리는 `JIRA`([HK-75](https://team-dopamine.atlassian.net/browse/HK-75?))에 정리해두었으니 읽어보시면 좋을 것 같습니다!
- Google OAuth 구현을 위해 공부한 자료도 위의 JIRA에 댓글로 남겨놓았습니다!
- 추가로 지난 일반 로그인에서 dto에 스키마에 오타를 발견하게 되어 수정하였습니다. (494bdabb5070ae4a6b9c967cd924711bb2ef3ed8)
<details>

<summary>API 테스트 결과</summary>
구글 OAuth 로그인 후 `WAS`에서 `access token` 및 `refresh token` 생성하여 Redirect URI로 반환한 결과입니다!

디테일하게는 스크럼때 확인하면 좋을 것 같습니다!

![구글 oauth 성공](https://github.com/user-attachments/assets/2cd32b7b-e29e-48f9-b4f4-3c874f44d56f)

</details>

[HK-75]: https://team-dopamine.atlassian.net/browse/HK-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HK-75]: https://team-dopamine.atlassian.net/browse/HK-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ