### PR TITLE
Feature(HK-76): GitHub OAuth 로그인 기능 구현

### DIFF
--- a/src/main/java/kr/husk/application/auth/config/GitHubConfig.java
+++ b/src/main/java/kr/husk/application/auth/config/GitHubConfig.java
@@ -1,0 +1,16 @@
+package kr.husk.application.auth.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties("oauth2.github")
+public class GitHubConfig {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String tokenUri;
+    private String userInfoUri;
+}

--- a/src/main/java/kr/husk/application/auth/service/GitHubOAuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/GitHubOAuthService.java
@@ -1,0 +1,107 @@
+package kr.husk.application.auth.service;
+
+import kr.husk.application.auth.config.GitHubConfig;
+import kr.husk.application.auth.dto.JwtTokenDto;
+import kr.husk.application.auth.dto.SignInDto;
+import kr.husk.common.exception.GlobalException;
+import kr.husk.common.jwt.util.JwtProvider;
+import kr.husk.domain.auth.entity.User;
+import kr.husk.domain.auth.exception.AuthExceptionCode;
+import kr.husk.domain.auth.service.UserService;
+import kr.husk.domain.auth.type.OAuthProvider;
+import kr.husk.infrastructure.persistence.ConcurrentMapRefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GitHubOAuthService {
+    private final UserService userService;
+    private final JwtProvider jwtProvider;
+    private final GitHubConfig gitHubConfig;
+    private final ConcurrentMapRefreshTokenRepository concurrentMapRefreshTokenRepository;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public ResponseEntity<SignInDto.Response> gitHubSignIn(@RequestParam("code") String code) {
+        String token = getToken(code);
+        Map<String, Object> userInfo = getGitHubUserInfo(token);
+        String email = userInfo.get("login") + "@github.com";
+
+        if (!userService.isExist(email, OAuthProvider.GITHUB)) {
+            User user = User.builder()
+                    .email(email)
+                    .password(null)
+                    .oAuthProvider(OAuthProvider.GITHUB)
+                    .build();
+
+            userService.create(user);
+        }
+
+        String accessToken = jwtProvider.generateAccessToken(email);
+        concurrentMapRefreshTokenRepository.create(email);
+        String refreshToken = concurrentMapRefreshTokenRepository.read(email).get();
+
+        JwtTokenDto tokenDto = JwtTokenDto.builder()
+                .grantType("Bearer ")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        SignInDto.Response response = new SignInDto.Response("GitHub OAuth 로그인 성공 ", tokenDto);
+
+        log.info("OAuth GitHub 로그인에 성공하였습니다. 이메일: {}", email);
+        return ResponseEntity.ok(response);
+    }
+
+    public String getToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", gitHubConfig.getClientId());
+        params.add("client_secret", gitHubConfig.getClientSecret());
+        params.add("redirect_uri", gitHubConfig.getRedirectUri());
+        params.add("code", code);
+
+        Map<String, Object> response = restTemplate.postForObject(gitHubConfig.getTokenUri(), params, Map.class);
+
+        if (response != null && response.containsKey("access_token")) {
+            return (String) response.get("access_token");
+        } else {
+            throw new GlobalException(AuthExceptionCode.ACCESSTOKEN_REQUEST_FAILED);
+        }
+
+    }
+
+    private Map<String, Object> getGitHubUserInfo(String accessToken) {
+        String userInfoUrl = gitHubConfig.getUserInfoUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.set("Accept", "application/json");
+
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+
+        Map<String, Object> userInfoResponse = restTemplate.exchange(userInfoUrl, HttpMethod.GET, entity, Map.class).getBody();
+
+        if (userInfoResponse != null) {
+            return userInfoResponse;
+        } else {
+            throw new GlobalException(AuthExceptionCode.GOOGLE_USERINFO_NOTFOUND);
+        }
+    }
+}

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -5,6 +5,7 @@ import kr.husk.application.auth.dto.SignInDto;
 import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.application.auth.service.AuthService;
+import kr.husk.application.auth.service.GitHubOAuthService;
 import kr.husk.application.auth.service.GoogleOAuthService;
 import kr.husk.common.exception.GlobalException;
 import kr.husk.domain.auth.exception.AuthExceptionCode;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController implements AuthApi {
     private final AuthService authService;
     private final GoogleOAuthService googleOAuthService;
+    private final GitHubOAuthService gitHubOAuthService;
 
     @Override
     @PostMapping("/send-code")
@@ -59,6 +61,8 @@ public class AuthController implements AuthApi {
     public ResponseEntity<?> signIn(@RequestParam("type") String type, @RequestParam("code") String code) {
         if ("google".equals(type)) {
             return ResponseEntity.ok(googleOAuthService.googleSignIn(code));
+        } else if ("github".equals(type)) {
+            return ResponseEntity.ok(gitHubOAuthService.gitHubSignIn(code));
         } else {
             throw new GlobalException(AuthExceptionCode.NOT_ALLOWED_TYPE);
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,9 @@ oauth2:
     redirect-uri: ${oauth2.google.redirect-uri}
     token-uri: ${oauth2.google.token-uri}
     user-info-uri: ${oauth2.google.user-info-uri}
+  github:
+    client-id: ${oauth2.github.client-id}
+    client-secret: ${oauth2.github.client-secret}
+    redirect-uri: ${oauth2.github.redirect-uri}
+    token-uri: ${oauth2.github.token-uri}
+    user-info-uri: ${oauth2.github.user-info-uri}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- ([HK-76](https://team-dopamine.atlassian.net/browse/HK-76?atlOrigin=eyJpIjoiZjYzMzBkMDZhNGE3NDg0NWE4MTU1OTU0YzZkZmFhMzciLCJwIjoiaiJ9))
- 편리한 서비스 이용을 위한 `GitHub OAuth2.0` 로그인 구현

## Problem Solving

<!-- 해결 방법 -->
- GitHub의 OAuth Apps를 통해 프로젝트 생성 후 `클라이언트 ID`, `클라이언트 Secret` 발급 및 `Redirect URI` 등록
- GitHub OAuth의 경우`userInfo`의 `email`이 `null`로 응답되는 경우가 있습니다. 따라서, `GitHub username` + `@github.com` 을 결합하여 이메일로 만들도록 구현.
  - ex) 주희님의 경우라면 `jujuj@github.com`으로 저장됩니다!

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- API 테스트 결과
  ![image](https://github.com/user-attachments/assets/b96827d2-433e-4cac-b359-496dd1a78d88)
- Redirect URI의 경우 같이 OAuth 로그인 연동하실 때, 같이 맞춰보면서 하면 될 것 같습니다!

[HK-76]: https://team-dopamine.atlassian.net/browse/HK-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ