### PR TITLE
Feature(HK-90): 서비스 로그아웃 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/auth/dto/SignOutDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SignOutDto.java
@@ -1,0 +1,31 @@
+package kr.husk.application.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class SignOutDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "SignOut.Request", description = "로그아웃 요청 DTO")
+    public static class Request {
+        private String refreshToken;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "SignOut.Response", description = "로그아웃 응답 DTO")
+    public static class Response {
+        @Setter
+        @Schema(description = "응답 메시지", example = "로그아웃에 성공하였습니다.")
+        private String message;
+
+        public static Response of(String message) {
+            return new Response(message);
+        }
+    }
+}

--- a/src/main/java/kr/husk/common/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/husk/common/jwt/filter/JwtAuthenticationFilter.java
@@ -27,7 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = jwtProvider.resolveToken(request);
 
         if (token != null && jwtProvider.validateToken(token)) {
-            String email = jwtProvider.getEmail(token.split(" ")[1].trim());
+            String email = jwtProvider.getEmail(token);
 
             Authentication authentication = new UsernamePasswordAuthenticationToken(
                     email, null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))

--- a/src/main/java/kr/husk/common/jwt/util/JwtProvider.java
+++ b/src/main/java/kr/husk/common/jwt/util/JwtProvider.java
@@ -51,10 +51,8 @@ public class JwtProvider {
 
     public boolean validateToken(String token) {
         try {
-            if (!token.startsWith("Bearer ")) {
+            if (token == null) {
                 return false;
-            } else {
-                token = token.split(" ")[1].trim();
             }
             Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(secret.getBytes()).build().parseClaimsJws(token);
             return !claims.getBody().getExpiration().before(new Date());
@@ -64,7 +62,11 @@ public class JwtProvider {
     }
 
     public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("Authorization");
+        String token = request.getHeader("Authorization");
+        if (token != null && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return null;
     }
 
     public String getEmail(String token) {

--- a/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
@@ -9,7 +9,11 @@ public enum AuthExceptionCode implements ExceptionCode {
     PASSWORD_MISMATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     GOOGLE_USERINFO_NOTFOUND(HttpStatus.NOT_FOUND, "Google 사용자 정보 요청에 실패했습니다."),
     ACCESSTOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "Google OAuth Access Token 요청에 실패했습니다."),
-    NOT_ALLOWED_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "허용되지 않은 OAuth 타입 요청입니다.");
+    NOT_ALLOWED_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "허용되지 않은 OAuth 타입 요청입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리프레시 토큰입니다.");
+
     HttpStatus httpStatus;
     String cause;
 

--- a/src/main/java/kr/husk/infrastructure/persistence/ConcurrentMapRefreshTokenRepository.java
+++ b/src/main/java/kr/husk/infrastructure/persistence/ConcurrentMapRefreshTokenRepository.java
@@ -38,7 +38,7 @@ public class ConcurrentMapRefreshTokenRepository implements RefreshTokenReposito
             return Optional.empty();
         }
 
-        if (jwtProvider.validateToken(refreshToken)) {
+        if (!jwtProvider.validateToken(refreshToken)) {
             refreshTokenMap.remove(email);
             return Optional.empty();
         }

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -6,9 +6,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
 import kr.husk.application.auth.dto.SignInDto;
+import kr.husk.application.auth.dto.SignOutDto;
 import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import org.springframework.http.ResponseEntity;
@@ -64,4 +66,11 @@ public interface AuthApi {
             @ApiResponse(responseCode = "400", description = "로그인 실패")
     })
     ResponseEntity<?> signIn(@RequestParam("type") String type, @RequestParam("code") String code);
+
+    @Operation(summary = "서비스 로그아웃", description = "서비스 로그아웃을 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "400", description = "로그아웃 실패")
+    })
+    ResponseEntity<?> signOut(@RequestBody SignOutDto.Request dto, HttpServletRequest request);
 }

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -1,7 +1,9 @@
 package kr.husk.presentation.rest;
 
+import jakarta.servlet.http.HttpServletRequest;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
 import kr.husk.application.auth.dto.SignInDto;
+import kr.husk.application.auth.dto.SignOutDto;
 import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.application.auth.service.AuthService;
@@ -66,5 +68,11 @@ public class AuthController implements AuthApi {
         } else {
             throw new GlobalException(AuthExceptionCode.NOT_ALLOWED_TYPE);
         }
+    }
+
+    @Override
+    @PostMapping("/sign-out")
+    public ResponseEntity<?> signOut(SignOutDto.Request dto, HttpServletRequest request) {
+        return ResponseEntity.ok(authService.signOut(dto, request));
     }
 }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 서비스 사용자들의 안전한 계정 관리를 위한 로그아웃 API 구현 필요성 대두
- JWT 토큰 관리 및 악용 우려에 대비 할 필요성이 있음.

## Problem Solving

<!-- 해결 방법 -->
- `/auth/sign-out` 을 통한 `SignOut` API 구현(5d4a61baac3956e5ebec43294862c9be66f4a4ac)
- `Access Token`을 통해 서버에 저장된 사용자의 `Refresh Token` 삭제(88e0721c4dc44c40d98408bd9d28980468901295)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- `OAuth2.0 (Google, GitHub) SignIn`과 `서비스 자체 SignIn` 을 중복 허용하는 경우에 대해서 문제가 발생
  - Jwt Token에 OAuth Platform 제공자인 `Provider`를 추가하여 `Provider` 검사를 이용하여 이메일 중복을 허용할 수 있으나 현재 작성된 코드를 다소 수정해야함.
  - 코드 수정과 더불어 현재는 `Refresh Token(value)`을 `email(key)`로 조회하는데 이중 로그인이 되어있는 경우`(ex. Google, 일반 로그인)` 로그아웃 시 처음에 로그인한 플랫폼으로 로그아웃 불가능(`Refresh Token이 유효하지 않음`)
  - 따라서, 사용자의 경험과 보안을 단순화 하기 위해서 `중복 이메일을 통한 로그인 및 회원가입을 불허함`

- 스크럼 때 말씀드린 것처럼, 우선은 위의 방향으로 진행하려고 합니다. 하지만, `Back-End` 상황에 따라 기존의 방향을 유지하는 쪽으로 진행할 수 있을 것 같습니다!

<details>
<summary>일반 계정 로그아웃 Test</summary>

![일반 로그아웃 테스트](https://github.com/user-attachments/assets/faeb5a20-6073-4f97-873c-ae79ce0c1b37)

</details>

<details>
<summary>구글 OAuth 계정 로그아웃 Test</summary>

![구글OAuth 로그아웃 테스트](https://github.com/user-attachments/assets/e4982027-aa0d-4841-b982-6ca5e3733c8a)

</details>

<details>
<summary>깃허브 OAuth 로그아웃 Test</summary>

![깃허브OAuth 로그아웃 테스트](https://github.com/user-attachments/assets/2885ba2c-d9a7-4c35-b51e-97bbe0ac7585)

</details>