### PR TITLE
Feature(HK-95): 일반 사용자 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/auth/dto/ChangePasswordDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/ChangePasswordDto.java
@@ -1,0 +1,41 @@
+package kr.husk.application.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class ChangePasswordDto {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "ChangePassword.Request", description = "사용자 비밀번호 재설정 요청 DTO")
+    public static class Request {
+        @NotBlank(message = "현재 비밀번호 입력은 필수값입니다.")
+        private String nowPassword;
+
+        @NotBlank(message = "새로운 비밀번호 입력은 필수값입니다.")
+        @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()-_=+]).{8,16}$",
+                message = "비밀번호는 8자 이상 16자 이하이며, 숫자, 소문자, 대문자, 특수문자를 포함해야 합니다.")
+        private String newPassword;
+
+        @NotBlank(message = "비밀번호 확인은 필수값입니다.")
+        private String confirmPassword;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ChangePassword.Response", description = "사용자 비밀번호 재설정 응답 DTO")
+    public static class Response {
+        @Setter
+        @Schema(name = "응답 메세지", description = "비밀번호 변경이 완료되었습니다.")
+        private String message;
+
+        public static Response of(String message) {
+            return new Response(message);
+        }
+    }
+}

--- a/src/main/java/kr/husk/domain/auth/entity/User.java
+++ b/src/main/java/kr/husk/domain/auth/entity/User.java
@@ -53,4 +53,8 @@ public class User extends BaseEntity {
     public boolean isMatched(PasswordEncoder passwordEncoder, String password) {
         return passwordEncoder.matches(password, this.password);
     }
+
+    public void updatePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
@@ -12,7 +12,8 @@ public enum AuthExceptionCode implements ExceptionCode {
     NOT_ALLOWED_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "허용되지 않은 OAuth 타입 요청입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리프레시 토큰입니다.");
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리프레시 토큰입니다."),
+    CONFIRM_PASSWORD_NOT_EQUAL(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다.");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/kr/husk/domain/auth/exception/UserExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/UserExceptionCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum UserExceptionCode implements ExceptionCode {
 
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
-    EMAIL_IS_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다.");
+    EMAIL_IS_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
+    OAUTH_PASSWORD_CHANGE_DENIED(HttpStatus.FORBIDDEN, "OAuth 계정은 비밀번호를 변경할 수 없습니다.");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/kr/husk/domain/auth/service/UserService.java
+++ b/src/main/java/kr/husk/domain/auth/service/UserService.java
@@ -24,6 +24,10 @@ public class UserService {
                 .orElseThrow(() -> new GlobalException(UserExceptionCode.EMAIL_IS_NOT_FOUND));
     }
 
+    public void update(User user, String newPassowrd) {
+        user.updatePassword(newPassowrd);
+    }
+
     public boolean isExist(String email, OAuthProvider oAuthProvider) {
         return userRepository.findByEmailAndOAuthProvider(email, oAuthProvider).isPresent();
     }

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import kr.husk.application.auth.dto.ChangePasswordDto;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
 import kr.husk.application.auth.dto.SignInDto;
 import kr.husk.application.auth.dto.SignOutDto;
@@ -73,4 +74,12 @@ public interface AuthApi {
             @ApiResponse(responseCode = "400", description = "로그아웃 실패")
     })
     ResponseEntity<?> signOut(@RequestBody SignOutDto.Request dto, HttpServletRequest request);
+
+    @Operation(summary = "사용자 비밀번호 재설정", description = "비밀번호 재설정을 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "재설정 비밀번호 불일치"),
+            @ApiResponse(responseCode = "403", description = "비밀번호 변경 실패 (사유: OAuth 사용자)")
+    })
+    ResponseEntity<?> updatePassword(@Valid @RequestBody ChangePasswordDto.Request dto, HttpServletRequest request);
 }

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -1,6 +1,7 @@
 package kr.husk.presentation.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
+import kr.husk.application.auth.dto.ChangePasswordDto;
 import kr.husk.application.auth.dto.SendAuthCodeDto;
 import kr.husk.application.auth.dto.SignInDto;
 import kr.husk.application.auth.dto.SignOutDto;
@@ -15,6 +16,7 @@ import kr.husk.presentation.api.AuthApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -74,5 +76,11 @@ public class AuthController implements AuthApi {
     @PostMapping("/sign-out")
     public ResponseEntity<?> signOut(SignOutDto.Request dto, HttpServletRequest request) {
         return ResponseEntity.ok(authService.signOut(dto, request));
+    }
+
+    @Override
+    @PatchMapping("/user")
+    public ResponseEntity<?> updatePassword(ChangePasswordDto.Request dto, HttpServletRequest request) {
+        return ResponseEntity.ok(authService.changePassword(dto, request));
     }
 }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 사용자 계정의 보안을 위한 비밀번호 변경 API 필요

## Problem Solving

<!-- 해결 방법 -->
- 비밀번호 변경에 대한 DTO 객체 구현 (2cc7ff79304491f40caf1513fd817542746686c1)
  - 현재 비밀번호, 새로운 비밀번호, 비밀번호 확인 (3가지를 확인받음)
  - 관련 예외코드 추가 (f9d7f5dc9cd06e2929f7b61c4643fb5d5677c084)
- User Entity의 비밀번호 변경 메소드 추가 (dc0dba1f399ed139376318667c98e5e7a037a168)
  - 비밀번호 변경 시 `사용자가 입력한 새로운 비밀번호로 설정 후 인코딩 실시`

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 현재 특수문자에 대한 검증이 제대로 이루어지고 있지 않습니다. `authorization`에 대한 `Backlog` 개발이 완료된다면 전반적인 코드를 확인해보고 리팩토링 할 예정입니다.
  - 정규표현식에서 `-`가 중간에 있어서 생기는 문제로 확인했음 