### PR TITLE
Feature(HK-96): 임시 비밀번호 발급 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/auth/dto/EmailDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/EmailDto.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-public class SendAuthCodeDto {
+public class EmailRequestDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/kr/husk/application/auth/dto/EmailDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/EmailDto.java
@@ -9,11 +9,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-public class EmailRequestDto {
+public class EmailDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(name = "SendAuthCode.Request", description = "인증 코드 전송 요청 DTO")
+    @Schema(name = "Email.Request", description = "메일 전송 요청 DTO")
     public static class Request {
         @NotBlank(message = "이메일은 필수 입력값입니다.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
@@ -29,7 +29,7 @@ public class EmailRequestDto {
 
     @Getter
     @AllArgsConstructor
-    @Schema(name = "SendAuthCode.Response", description = "인증 코드 전송 응답 DTO")
+    @Schema(name = "Email.Response", description = "메일 전송 응답 DTO")
     public static class Response {
         @Setter
         @Schema(description = "응답 메시지", example = "인증 코드가 전송되었습니다.")

--- a/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                                         "/auth/sign-up",
                                         "/auth/sign-in",
                                         "/auth/terms-of-service",
+                                        "/auth/password/reset",
                                         "/swagger-resources/**",
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import kr.husk.application.auth.dto.ChangePasswordDto;
-import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.EmailDto;
 import kr.husk.application.auth.dto.SignInDto;
 import kr.husk.application.auth.dto.SignOutDto;
 import kr.husk.application.auth.dto.SignUpDto;
@@ -26,12 +26,12 @@ public interface AuthApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "인증 코드 전송 성공",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = SendAuthCodeDto.Response.class)
+                            schema = @Schema(implementation = EmailDto.Response.class)
                     )
             ),
             @ApiResponse(responseCode = "400", description = "인증 코드 전송 실패")
     })
-    ResponseEntity<?> sendAuthCode(@RequestBody SendAuthCodeDto.Request dto);
+    ResponseEntity<?> sendAuthCode(@RequestBody EmailDto.Request dto);
 
     @Operation(summary = "인증 코드 검증", description = "이메일로 전송된 인증 코드를 검증하기 위한 API")
     @ApiResponses({
@@ -82,4 +82,11 @@ public interface AuthApi {
             @ApiResponse(responseCode = "403", description = "비밀번호 변경 실패 (사유: OAuth 사용자)")
     })
     ResponseEntity<?> updatePassword(@Valid @RequestBody ChangePasswordDto.Request dto, HttpServletRequest request);
+
+    @Operation(summary = "사용자 임시 비밀번호 발급", description = "임시 비밀번호 발급을 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "임시 비밀번호 발급 성공"),
+            @ApiResponse(responseCode = "400", description = "임시 비밀번호 발급 실패")
+    })
+    ResponseEntity<?> resetPassword(@RequestBody EmailDto.Request dto);
 }

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -2,7 +2,7 @@ package kr.husk.presentation.rest;
 
 import jakarta.servlet.http.HttpServletRequest;
 import kr.husk.application.auth.dto.ChangePasswordDto;
-import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.EmailDto;
 import kr.husk.application.auth.dto.SignInDto;
 import kr.husk.application.auth.dto.SignOutDto;
 import kr.husk.application.auth.dto.SignUpDto;
@@ -32,7 +32,7 @@ public class AuthController implements AuthApi {
 
     @Override
     @PostMapping("/send-code")
-    public ResponseEntity<?> sendAuthCode(SendAuthCodeDto.Request dto) {
+    public ResponseEntity<?> sendAuthCode(EmailDto.Request dto) {
         return ResponseEntity.ok(authService.sendAuthCode(dto));
     }
 
@@ -82,5 +82,11 @@ public class AuthController implements AuthApi {
     @PatchMapping("/user")
     public ResponseEntity<?> updatePassword(ChangePasswordDto.Request dto, HttpServletRequest request) {
         return ResponseEntity.ok(authService.changePassword(dto, request));
+    }
+
+    @Override
+    @PostMapping("/password/reset")
+    public ResponseEntity<?> resetPassword(EmailDto.Request dto) {
+        return ResponseEntity.ok(authService.sendTemporaryPassword(dto));
     }
 }

--- a/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
+++ b/src/test/java/kr/husk/presentation/rest/AuthControllerTest.java
@@ -1,7 +1,7 @@
 package kr.husk.presentation.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.husk.application.auth.dto.SendAuthCodeDto;
+import kr.husk.application.auth.dto.EmailDto;
 import kr.husk.application.auth.dto.SignUpDto;
 import kr.husk.application.auth.dto.VerifyAuthCodeDto;
 import kr.husk.application.auth.service.AuthService;
@@ -32,10 +32,10 @@ class AuthControllerTest {
     @Test
     void sendAuthCodeApiTest() throws Exception {
         // give
-        SendAuthCodeDto.Request dto = new SendAuthCodeDto.Request("jinlee1703@gmail.com");
+        EmailDto.Request dto = new EmailDto.Request("jinlee1703@gmail.com");
 
         // when
-        when(authService.sendAuthCode(dto)).thenReturn(SendAuthCodeDto.Response.of("인증 코드가 성공적으로 전송되었습니다."));
+        when(authService.sendAuthCode(dto)).thenReturn(EmailDto.Response.of("인증 코드가 성공적으로 전송되었습니다."));
 
         // then
         mockMvc.perform(post("/auth/send-code")


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 해당 서비스 사용자가 비밀번호를 잃어버린 경우, 사용자가 로그인 후 비밀번호를 재설정 할 수 있도록 해야함.
- `사용자는 이메일 인증 후 임시 비밀번호를 이메일로 받을 수 있음.`

## Problem Solving

<!-- 해결 방법 -->
- 기존의 비밀번호 규칙을 지켜서 랜덤 문자열 생성(`특수문자 1개 이상, 영어 대/소문자 각 1개 이상, 숫자 1개 이상`) (3f30a8b47be74755df015f0d631a3fc253a79e21)
- 임시 비밀번호 발급이 기존의 인증 코드 전송과 로직이 동일하여 기존의 인증 코드 전송을 위한 dto에 대해 리팩토링 진행 (10424a09d079eccf07654bf6770a1c4decb26818)
  - `SendAuthCodeDto → EmailDto`로 수정
  - `AuthService` 에서의 `sendEmail()` 메소드도 인증 코드에 대한 내용으로만 설정되어 있었으나 해당 메소드 호출 시 내용을 설정할 수 있도록 수정

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- X