### PR TITLE
Feature(HK-97): 서비스 사용자의 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/auth/config/GitHubConfig.java
+++ b/src/main/java/kr/husk/application/auth/config/GitHubConfig.java
@@ -13,4 +13,5 @@ public class GitHubConfig {
     private String redirectUri;
     private String tokenUri;
     private String userInfoUri;
+    private String revokeUrl;
 }

--- a/src/main/java/kr/husk/application/auth/config/GoogleConfig.java
+++ b/src/main/java/kr/husk/application/auth/config/GoogleConfig.java
@@ -14,4 +14,5 @@ public class GoogleConfig {
     private String redirectUri;
     private String tokenUri;
     private String userInfoUri;
+    private String revokeUrl;
 }

--- a/src/main/java/kr/husk/application/auth/service/GoogleOAuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/GoogleOAuthService.java
@@ -7,11 +7,14 @@ import kr.husk.common.exception.GlobalException;
 import kr.husk.common.jwt.util.JwtProvider;
 import kr.husk.domain.auth.entity.User;
 import kr.husk.domain.auth.exception.AuthExceptionCode;
+import kr.husk.domain.auth.exception.UserExceptionCode;
+import kr.husk.domain.auth.repository.OAuthTokenRepository;
 import kr.husk.domain.auth.service.UserService;
 import kr.husk.domain.auth.type.OAuthProvider;
 import kr.husk.infrastructure.persistence.ConcurrentMapRefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -33,21 +36,15 @@ public class GoogleOAuthService {
     private final GoogleConfig googleConfig;
     private final ConcurrentMapRefreshTokenRepository concurrentMapRefreshTokenRepository;
     private final RestTemplate restTemplate = new RestTemplate();
+    private final OAuthTokenRepository oAuthTokenRepository;
 
     public ResponseEntity<SignInDto.Response> googleSignIn(@RequestParam("code") String code) {
         String token = getToken(code);
         Map<String, Object> userInfo = getGoogleUserInfo(token);
         String email = (String) userInfo.get("email");
+        oAuthTokenRepository.create(email, token);
 
-        if (!userService.isExist(email, OAuthProvider.GOOGLE)) {
-            User user = User.builder()
-                    .email(email)
-                    .password(null)
-                    .oAuthProvider(OAuthProvider.GOOGLE)
-                    .build();
-
-            userService.create(user);
-        }
+        checkUser(email);
 
         String accessToken = jwtProvider.generateAccessToken(email);
         concurrentMapRefreshTokenRepository.create(email);
@@ -95,6 +92,51 @@ public class GoogleOAuthService {
             return userInfoResponse;
         } else {
             throw new GlobalException(AuthExceptionCode.GOOGLE_USERINFO_NOTFOUND);
+        }
+    }
+
+    public void checkUser(String email) {
+        User user = userService.read(email);
+        if (user != null && user.getOAuthProvider() != OAuthProvider.GOOGLE) {
+            throw new GlobalException(UserExceptionCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        if (user == null) {
+            User newUser = User.builder()
+                    .email(email)
+                    .password(null)
+                    .oAuthProvider(OAuthProvider.GOOGLE)
+                    .build();
+
+            userService.create(newUser);
+        } else {
+            if (user.isDeleted()) {
+                if (user.isWithin30DaysFromDeletion()) {
+                    log.info("[Google OAuth] 30일 이내에 탈퇴한 OAuth 계정으로 로그인이 시도되어 계정이 복구됩니다.");
+                    user.restore();
+                    userService.update(user, null);
+                } else {
+                    throw new GlobalException(UserExceptionCode.WITHDRAWN_USER);
+                }
+            }
+        }
+    }
+
+    public void unlink(String email) {
+        try {
+            String token = oAuthTokenRepository.read(email);
+            String revokeUrl = googleConfig.getRevokeUrl() + "?token=" + token;
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            HttpEntity<String> request = new HttpEntity<>(headers);
+            restTemplate.postForEntity(revokeUrl, request, String.class);
+
+            log.info("[Google OAuth] 이메일: {}이 연결 해제 되었습니다.", email);
+        } catch (Exception e) {
+            log.error("[Google OAuth] 이메일: {}의 연결 해제 중 오류가 발생하였습니다.", email);
+            throw new GlobalException(AuthExceptionCode.OAUTH_UNLINK_FAILED);
         }
     }
 }

--- a/src/main/java/kr/husk/common/entity/BaseEntity.java
+++ b/src/main/java/kr/husk/common/entity/BaseEntity.java
@@ -1,6 +1,11 @@
 package kr.husk.common.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
@@ -8,6 +13,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -35,5 +41,14 @@ public class BaseEntity {
 
     public boolean isDeleted() {
         return deletedAt != null;
+    }
+
+    public boolean isWithin30DaysFromDeletion() {
+        if (this.deletedAt == null) return false;
+        return ChronoUnit.DAYS.between(this.deletedAt, LocalDateTime.now()) <= 30;
+    }
+
+    public void restore() {
+        this.deletedAt = null;
     }
 }

--- a/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
@@ -13,7 +13,8 @@ public enum AuthExceptionCode implements ExceptionCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리프레시 토큰입니다."),
-    CONFIRM_PASSWORD_NOT_EQUAL(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다.");
+    CONFIRM_PASSWORD_NOT_EQUAL(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),
+    OAUTH_UNLINK_FAILED(HttpStatus.BAD_REQUEST, "계정 연결 해제에 실패하였습니다.)");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/kr/husk/domain/auth/exception/UserExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/UserExceptionCode.java
@@ -7,7 +7,8 @@ public enum UserExceptionCode implements ExceptionCode {
 
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
     EMAIL_IS_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
-    OAUTH_PASSWORD_CHANGE_DENIED(HttpStatus.FORBIDDEN, "OAuth 계정은 비밀번호를 변경할 수 없습니다.");
+    OAUTH_PASSWORD_CHANGE_DENIED(HttpStatus.FORBIDDEN, "OAuth 계정은 비밀번호를 변경할 수 없습니다."),
+    WITHDRAWN_USER(HttpStatus.FORBIDDEN, "이미 탈퇴한 계정입니다.");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/kr/husk/domain/auth/repository/OAuthTokenRepository.java
+++ b/src/main/java/kr/husk/domain/auth/repository/OAuthTokenRepository.java
@@ -1,0 +1,9 @@
+package kr.husk.domain.auth.repository;
+
+public interface OAuthTokenRepository {
+    void create(String email, String oAuthToken);
+
+    String read(String email);
+
+    void delete(String email);
+}

--- a/src/main/java/kr/husk/domain/auth/repository/UserRepository.java
+++ b/src/main/java/kr/husk/domain/auth/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM user u WHERE u.email = :email And u.oAuthProvider = :oAuthProvider")
     Optional<User> findByEmailAndOAuthProvider(String email, OAuthProvider oAuthProvider);
 
+    Optional<User> findByEmail(String email);
+
 }

--- a/src/main/java/kr/husk/domain/auth/service/UserService.java
+++ b/src/main/java/kr/husk/domain/auth/service/UserService.java
@@ -24,6 +24,10 @@ public class UserService {
                 .orElseThrow(() -> new GlobalException(UserExceptionCode.EMAIL_IS_NOT_FOUND));
     }
 
+    public User read(String email) {
+        return userRepository.findByEmail(email).orElse(null);
+    }
+
     public void update(User user, String newPassowrd) {
         user.updatePassword(newPassowrd);
     }

--- a/src/main/java/kr/husk/infrastructure/persistence/ConcurrentMapOAuthTokenRepository.java
+++ b/src/main/java/kr/husk/infrastructure/persistence/ConcurrentMapOAuthTokenRepository.java
@@ -1,0 +1,28 @@
+package kr.husk.infrastructure.persistence;
+
+import kr.husk.domain.auth.repository.OAuthTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+@RequiredArgsConstructor
+public class ConcurrentMapOAuthTokenRepository implements OAuthTokenRepository {
+    private final ConcurrentHashMap<String, String> oAuthTokenMap = new ConcurrentHashMap<>();
+
+    @Override
+    public void create(String email, String oAuthToken) {
+        oAuthTokenMap.put(email, oAuthToken);
+    }
+
+    @Override
+    public String read(String email) {
+        return oAuthTokenMap.get(email);
+    }
+
+    @Override
+    public void delete(String email) {
+        oAuthTokenMap.remove(email);
+    }
+}

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -89,4 +89,11 @@ public interface AuthApi {
             @ApiResponse(responseCode = "400", description = "임시 비밀번호 발급 실패")
     })
     ResponseEntity<?> resetPassword(@RequestBody EmailDto.Request dto);
+
+    @Operation(summary = "사용자 서비스 계정 탈퇴", description = "사용자 서비스 계정 탈퇴 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "계정 탈퇴 완료"),
+            @ApiResponse(responseCode = "400", description = "계정 탈퇴 실패")
+    })
+    ResponseEntity<?> withdraw(HttpServletRequest request);
 }

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -89,4 +89,10 @@ public class AuthController implements AuthApi {
     public ResponseEntity<?> resetPassword(EmailDto.Request dto) {
         return ResponseEntity.ok(authService.sendTemporaryPassword(dto));
     }
+
+    @Override
+    @PatchMapping("/withdraw")
+    public ResponseEntity<?> withdraw(HttpServletRequest request) {
+        return ResponseEntity.ok(authService.withdraw(request));
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,9 +53,11 @@ oauth2:
     redirect-uri: ${oauth2.google.redirect-uri}
     token-uri: ${oauth2.google.token-uri}
     user-info-uri: ${oauth2.google.user-info-uri}
+    revoke-url: ${oauth2.google.revoke-url}
   github:
     client-id: ${oauth2.github.client-id}
     client-secret: ${oauth2.github.client-secret}
     redirect-uri: ${oauth2.github.redirect-uri}
     token-uri: ${oauth2.github.token-uri}
     user-info-uri: ${oauth2.github.user-info-uri}
+    revoke-url: ${oauth2.github.revoke-url}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 서비스 사용자의 계정 탈퇴 API 구현 필요
- 데이터의 무결성 및 결함을 최소화 하기 위해 `soft delete` 방식으로 탈퇴 로직 구현

## Problem Solving

<!-- 해결 방법 -->
- 사용자의 회원 상태에서 `deleted_at`을 설정함으로써 회원 탈퇴 시 `soft delete` 처리
- `OAuth 사용자`의 경우 로그인 시 `OAuth 제공 플랫폼`으로부터 받은 `액세스 코드를 통해 탈퇴 처리`함.
- 탈퇴 후 30일이내 재가입(OAuth 계정의 경우 재로그인) 시 계정 복구. 

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- `Google`, `GitHub`, `일반 계정` 모두 테스트 완료했으며 문제없이 동작함을 확인했습니다.
- 코드를 리팩토링 해야할 부분이 많은데 앞선 PR에서 말씀드렸듯 `authorization` 스토리 마무리 후 진행할 예정입니다.