### PR TITLE
Refactor(HK-104): Authorization Code Refactoring

### DIFF
--- a/src/main/java/kr/husk/application/auth/dto/ChangePasswordDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/ChangePasswordDto.java
@@ -15,7 +15,7 @@ public class ChangePasswordDto {
     @Schema(name = "ChangePassword.Request", description = "사용자 비밀번호 재설정 요청 DTO")
     public static class Request {
         @NotBlank(message = "현재 비밀번호 입력은 필수값입니다.")
-        private String nowPassword;
+        private String currentPassword;
 
         @NotBlank(message = "새로운 비밀번호 입력은 필수값입니다.")
         @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()-_=+]).{8,16}$",

--- a/src/main/java/kr/husk/application/auth/dto/SignInDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SignInDto.java
@@ -22,7 +22,7 @@ public class SignInDto {
         private String email;
 
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-        @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()-_=+]).{8,16}$",
+        @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()_=+-]).{8,16}$",
                 message = "비밀번호는 8자 이상 16자 이하이며, 숫자, 소문자, 대문자, 특수문자를 포함해야 합니다.")
         private String password;
 

--- a/src/main/java/kr/husk/application/auth/dto/SignUpDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/SignUpDto.java
@@ -24,7 +24,7 @@ public class SignUpDto {
         private String email;
 
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-        @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()-_=+]).{8,16}$",
+        @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()_=+-]).{8,16}$",
                 message = "비밀번호는 8자 이상 16자 이하이며, 숫자, 소문자, 대문자, 특수문자를 포함해야 합니다.")
         private String password;
 

--- a/src/main/java/kr/husk/application/auth/dto/WithdrawDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/WithdrawDto.java
@@ -1,0 +1,25 @@
+package kr.husk.application.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+public class WithdrawDto {
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "Withdraw.Response", description = "회원 탈퇴 응답 DTO")
+    public static class Response {
+        @Setter
+        @Schema(description = "응답 메시지", example = "탈퇴 처리가 성공적으로 완료되었습니다.")
+        private String message;
+        private LocalDateTime withdrawnAt;
+
+        public static Response of(String message) {
+            return new Response(message, LocalDateTime.now());
+        }
+    }
+}

--- a/src/main/java/kr/husk/application/auth/service/GitHubOAuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/GitHubOAuthService.java
@@ -98,7 +98,7 @@ public class GitHubOAuthService {
         if (userInfoResponse != null) {
             return userInfoResponse;
         } else {
-            throw new GlobalException(AuthExceptionCode.GOOGLE_USERINFO_NOTFOUND);
+            throw new GlobalException(AuthExceptionCode.OAUTH_USERINFO_NOTFOUND);
         }
     }
 

--- a/src/main/java/kr/husk/application/auth/service/GoogleOAuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/GoogleOAuthService.java
@@ -91,7 +91,7 @@ public class GoogleOAuthService {
         if (userInfoResponse != null) {
             return userInfoResponse;
         } else {
-            throw new GlobalException(AuthExceptionCode.GOOGLE_USERINFO_NOTFOUND);
+            throw new GlobalException(AuthExceptionCode.OAUTH_USERINFO_NOTFOUND);
         }
     }
 

--- a/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
@@ -7,7 +7,7 @@ public enum AuthExceptionCode implements ExceptionCode {
     VERIFICATION_CODE_NOT_MATCH(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 메일 발송에 실패했습니다."),
     PASSWORD_MISMATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    GOOGLE_USERINFO_NOTFOUND(HttpStatus.NOT_FOUND, "Google 사용자 정보 요청에 실패했습니다."),
+    OAUTH_USERINFO_NOTFOUND(HttpStatus.NOT_FOUND, "OAuth 플랫폼에 사용자 정보가 존재하지 않습니다."),
     ACCESSTOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "Google OAuth Access Token 요청에 실패했습니다."),
     NOT_ALLOWED_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "허용되지 않은 OAuth 타입 요청입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -61,7 +61,7 @@ public interface AuthApi {
     })
     ResponseEntity<?> signIn(@Valid @RequestBody SignInDto.Request dto);
 
-    @Operation(summary = "Google OAuth 로그인", description = "Google OAuth 로그인을 위한 API")
+    @Operation(summary = "OAuth 로그인", description = "OAuth 로그인을 위한 API")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
             @ApiResponse(responseCode = "400", description = "로그인 실패")


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- Back-End의 MVP 1.0 Authorization 도메인의 API 개발 완료.
- Authorization API 개발 과정에서 작성한 코드 정리 및 오타 수정

## Problem Solving

<!-- 해결 방법 -->
- 회원 탈퇴 시 message 반환 → WithdrawDto 객체를 추가하여 dto 객체로 반환 (3e4e4c7299482e9e4a59c5e96e611b963c23f6c4)
- Swagger `Sign-In` 스키마 수정
- GitHubOAuthService 및 GoogleOAuthService에서 동일한 예외 코드를 반환하도록 일치시킴. (52603a89e949c6bd54fe8e7606ca527bdf1cd900)
## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- X