### PR TITLE
Feature(HK-109): 키체인(키페어) 등록을 위한 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
+++ b/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
@@ -1,0 +1,37 @@
+package kr.husk.application.keychain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class KeyChainDto {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "KeyChain.Request", description = "키체인 등록 요청 DTO")
+    public static class Request {
+        @NotBlank(message = "이름은 필수 입력값입니다.")
+        @Schema(description = "키체인명", example = "test")
+        private String name;
+
+        @NotBlank(message = "키체인 내용은 필수 입력값입니다.")
+        @Schema(description = "키체인 내용", example = "MSxzAclsdQsdp")
+        private String content;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "KeyChain.Response", description = "키체인 등록 응답 DTO")
+    public static class Response {
+        @Setter
+        @Schema(description = "응답 메시지", example = "키체인 등록이 완료되었습니다.")
+        private String message;
+
+        public static Response of(String message) {
+            return new Response(message);
+        }
+    }
+}

--- a/src/main/java/kr/husk/common/service/EncryptionService.java
+++ b/src/main/java/kr/husk/common/service/EncryptionService.java
@@ -1,0 +1,22 @@
+package kr.husk.common.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.encrypt.BytesEncryptor;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+public class EncryptionService {
+
+    private final BytesEncryptor bytesEncryptor;
+
+    public String encrypt(String value) {
+        byte[] contentBytes = value.getBytes(StandardCharsets.UTF_8);
+        byte[] encryptedBytes = bytesEncryptor.encrypt(contentBytes);
+        return Base64.getEncoder().encodeToString(encryptedBytes);
+    }
+
+}

--- a/src/main/java/kr/husk/domain/keychain/entity/KeyChain.java
+++ b/src/main/java/kr/husk/domain/keychain/entity/KeyChain.java
@@ -1,6 +1,11 @@
 package kr.husk.domain.keychain.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import kr.husk.common.entity.BaseEntity;
 import kr.husk.domain.auth.entity.User;
 import lombok.AccessLevel;
@@ -16,7 +21,7 @@ public class KeyChain extends BaseEntity {
 
     @Column(name = "name", nullable = false, length = 20)
     private String name;
-    @Column(name = "content", nullable = false, length = 1024)
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Builder

--- a/src/main/java/kr/husk/domain/keychain/repository/KeyChainRepository.java
+++ b/src/main/java/kr/husk/domain/keychain/repository/KeyChainRepository.java
@@ -1,0 +1,7 @@
+package kr.husk.domain.keychain.repository;
+
+import kr.husk.domain.keychain.entity.KeyChain;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KeyChainRepository extends JpaRepository<KeyChain, Long> {
+}

--- a/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
+++ b/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
@@ -1,0 +1,46 @@
+package kr.husk.domain.keychain.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.husk.application.keychain.dto.KeyChainDto;
+import kr.husk.common.exception.GlobalException;
+import kr.husk.common.jwt.util.JwtProvider;
+import kr.husk.common.service.EncryptionService;
+import kr.husk.domain.auth.entity.User;
+import kr.husk.domain.auth.exception.AuthExceptionCode;
+import kr.husk.domain.auth.service.UserService;
+import kr.husk.domain.keychain.entity.KeyChain;
+import kr.husk.domain.keychain.repository.KeyChainRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KeyChainService {
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
+    private final EncryptionService encryptionService;
+    private final KeyChainRepository keyChainRepository;
+
+    public KeyChainDto.Response create(HttpServletRequest request, KeyChainDto.Request dto) {
+        String accessToken = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(accessToken);
+
+        if (!jwtProvider.validateToken(accessToken)) {
+            throw new GlobalException(AuthExceptionCode.INVALID_ACCESS_TOKEN);
+        }
+
+        User user = userService.read(email);
+        KeyChain keyChain = KeyChain.builder()
+                .user(user)
+                .name(dto.getName())
+                .content(encryptionService.encrypt(dto.getContent()))
+                .build();
+
+        keyChainRepository.save(keyChain);
+        log.info(email + "님의 키체인 [" + dto.getName() + "]이(가) 등록되었습니다.");
+        return KeyChainDto.Response.of("키체인 등록이 완료되었습니다.");
+    }
+
+}

--- a/src/main/java/kr/husk/infrastructure/config/EncryptionConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/EncryptionConfig.java
@@ -1,0 +1,21 @@
+package kr.husk.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.encrypt.BytesEncryptor;
+import org.springframework.security.crypto.encrypt.Encryptors;
+
+@Configuration
+public class EncryptionConfig {
+
+    @Value("${encryption.salt}")
+    private String salt;
+    @Value("${encryption.password}")
+    private String password;
+
+    @Bean
+    public BytesEncryptor bytesEncryptor() {
+        return Encryptors.stronger(password, salt);
+    }
+}

--- a/src/main/java/kr/husk/presentation/api/KeyChainApi.java
+++ b/src/main/java/kr/husk/presentation/api/KeyChainApi.java
@@ -1,0 +1,27 @@
+package kr.husk.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import kr.husk.application.keychain.dto.KeyChainDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "[키체인 관련 API]", description = "키체인(키페어) 관련 API")
+public interface KeyChainApi {
+    @Operation(summary = "키체인 등록", description = "키체인 등록을 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "키체인 등록 완료",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = KeyChainDto.Response.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "키체인 등록 실패")
+    })
+    ResponseEntity<?> create(HttpServletRequest request, @Valid @RequestBody KeyChainDto.Request dto);
+}

--- a/src/main/java/kr/husk/presentation/rest/KeyChainController.java
+++ b/src/main/java/kr/husk/presentation/rest/KeyChainController.java
@@ -1,0 +1,25 @@
+package kr.husk.presentation.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.husk.application.keychain.dto.KeyChainDto;
+import kr.husk.domain.keychain.service.KeyChainService;
+import kr.husk.presentation.api.KeyChainApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/keychains")
+@RequiredArgsConstructor
+public class KeyChainController implements KeyChainApi {
+
+    private final KeyChainService keyChainService;
+
+    @Override
+    @PostMapping("")
+    public ResponseEntity<?> create(HttpServletRequest request, KeyChainDto.Request dto) {
+        return ResponseEntity.ok(keyChainService.create(request, dto));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: 'aws-parameterstore:/config/husk/'
+    import: 'optional:aws-parameterstore:/config/husk/'
   datasource:
     url: ${jdbc.url}
     username: ${jdbc.username}
@@ -61,3 +61,7 @@ oauth2:
     token-uri: ${oauth2.github.token-uri}
     user-info-uri: ${oauth2.github.user-info-uri}
     revoke-url: ${oauth2.github.revoke-url}
+
+encryption:
+  salt: ${encryption.salt}
+  password: ${encryption.password}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: 'optional:aws-parameterstore:/config/husk/'
+    import: 'aws-parameterstore:/config/husk/'
   datasource:
     url: ${jdbc.url}
     username: ${jdbc.username}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 서비스 사용자의 편의를 위한 키체인(키페어) 저장 기능 필요성 대두
- ssh connection 시 필요한 키체인(키페어)를 저장하기 위한 API 구현 필요
## Problem Solving

<!-- 해결 방법 -->
- `keychain` 등록 시 보안을 위한 암호화 설정 (2419702b56a431fe4749b18c5cd1cda769027271)
- 기존 `keychain` 객체의 content 크기가 1024로 키페어의 크기보다 작아서 저장하지 못하는 문제가 발생하여 컬럼 속성을 `TEXT`로 변경 (caf12af3a71e15175a5cb8165ccc50c7f11b6c59)
- 이외 controller, service, repository, dto 생성 (이외 커밋 참고)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 더 좋은 방법이나 궁금한 부분, 오타 및 불필요한 부분이 있는지 확인 부탁드립니다!

<details>
<summary>API 테스트</summary>

![image](https://github.com/user-attachments/assets/78ec8d7c-c851-4c3d-8a0e-771dfde5a591)
![image](https://github.com/user-attachments/assets/ea28f0e9-b500-459b-9fde-56e1986fbfe9)
![image](https://github.com/user-attachments/assets/eb876cfd-7976-49a7-bce4-e259b7614dcf)


</details>