### PR TITLE
Feature(HK-113): 키체인 조회 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
+++ b/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
@@ -44,7 +44,7 @@ public class KeyChainDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(name = "KeyChain.KeyChainInfo", description = "키체인 등록 응답 DTO")
+    @Schema(name = "KeyChain.KeyChainInfo", description = "키체인 조회 응답 DTO")
     public static class KeyChainInfo {
         @Schema(description = "키체인 id", example = "1")
         private Long id;

--- a/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
+++ b/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
@@ -2,10 +2,15 @@ package kr.husk.application.keychain.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import kr.husk.domain.keychain.entity.KeyChain;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class KeyChainDto {
     @Getter
@@ -32,6 +37,28 @@ public class KeyChainDto {
 
         public static Response of(String message) {
             return new Response(message);
+        }
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "KeyChain.KeyChainInfo", description = "키체인 등록 응답 DTO")
+    public static class KeyChainInfo {
+        @Schema(description = "키체인 id", example = "1")
+        private Long id;
+
+        @Schema(description = "키체인명", example = "husk")
+        private String name;
+
+        public static List<KeyChainInfo> from(List<KeyChain> keyChains) {
+            return keyChains.stream()
+                    .map(keyChain -> KeyChainInfo.builder()
+                            .id(keyChain.getId())
+                            .name(keyChain.getName())
+                            .build())
+                    .collect(Collectors.toUnmodifiableList());
         }
     }
 }

--- a/src/main/java/kr/husk/common/entity/BaseEntity.java
+++ b/src/main/java/kr/husk/common/entity/BaseEntity.java
@@ -51,4 +51,8 @@ public class BaseEntity {
     public void restore() {
         this.deletedAt = null;
     }
+
+    public Long getId() {
+        return this.id;
+    }
 }

--- a/src/main/java/kr/husk/domain/keychain/entity/KeyChain.java
+++ b/src/main/java/kr/husk/domain/keychain/entity/KeyChain.java
@@ -10,8 +10,10 @@ import kr.husk.common.entity.BaseEntity;
 import kr.husk.domain.auth.entity.User;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity(name = "keychain")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class KeyChain extends BaseEntity {

--- a/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
+++ b/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -41,6 +43,18 @@ public class KeyChainService {
         keyChainRepository.save(keyChain);
         log.info(email + "님의 키체인 [" + dto.getName() + "]이(가) 등록되었습니다.");
         return KeyChainDto.Response.of("키체인 등록이 완료되었습니다.");
+    }
+
+    public List<KeyChainDto.KeyChainInfo> read(HttpServletRequest request) {
+        String accessToken = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(accessToken);
+
+        if (!jwtProvider.validateToken(accessToken)) {
+            throw new GlobalException(AuthExceptionCode.INVALID_ACCESS_TOKEN);
+        }
+
+        User user = userService.read(email);
+        return KeyChainDto.KeyChainInfo.from(user.getKeyChains());
     }
 
 }

--- a/src/main/java/kr/husk/presentation/api/KeyChainApi.java
+++ b/src/main/java/kr/husk/presentation/api/KeyChainApi.java
@@ -24,4 +24,15 @@ public interface KeyChainApi {
             @ApiResponse(responseCode = "400", description = "키체인 등록 실패")
     })
     ResponseEntity<?> create(HttpServletRequest request, @Valid @RequestBody KeyChainDto.Request dto);
+
+    @Operation(summary = "키체인 조회", description = "키체인 조회를 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "키체인 조회 완료",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = KeyChainDto.Response.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "키체인 조회 실패")
+    })
+    ResponseEntity<?> read(HttpServletRequest request);
 }

--- a/src/main/java/kr/husk/presentation/rest/KeyChainController.java
+++ b/src/main/java/kr/husk/presentation/rest/KeyChainController.java
@@ -6,6 +6,7 @@ import kr.husk.domain.keychain.service.KeyChainService;
 import kr.husk.presentation.api.KeyChainApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,5 +22,11 @@ public class KeyChainController implements KeyChainApi {
     @PostMapping("")
     public ResponseEntity<?> create(HttpServletRequest request, KeyChainDto.Request dto) {
         return ResponseEntity.ok(keyChainService.create(request, dto));
+    }
+
+    @Override
+    @GetMapping("")
+    public ResponseEntity<?> read(HttpServletRequest request) {
+        return ResponseEntity.ok(keyChainService.read(request));
     }
 }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 서비스 DashBoard 기능을 위한 키체인 조회 API 구현
- 사용자가 등록한 키체인의 목록을 확인할 수 있음.

## Problem Solving

<!-- 해결 방법 -->
- 관련 DTO 객체 추가 (8e9d33c961ce448146ec566ffa2fa94c009cb431)
- Controller, Service 로직 추가 (b09bc98a81fada7574089a1e6160f9d7dad6dd0b)
- 추가적으로, 말씀드린대로 키체인의 `content`는 별도의 복호화 버튼을 구현하고 해당 버튼을 누른 경우 `content`가 보여지도록 합니다.

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
<details> 

<summary>API 테스트 결과</summary>

![image](https://github.com/user-attachments/assets/4c976e23-581f-427d-beb8-17cd62b7d8ef)

</details>