### PR TITLE
Feature(HK-110): 키체인 수정을 위한 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
+++ b/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
@@ -52,6 +52,9 @@ public class KeyChainDto {
         @Schema(description = "키체인명", example = "husk")
         private String name;
 
+        @Schema(description = "키체인 내용", example = "Mxsa59s*2d^dsa")
+        private String content;
+
         public static List<KeyChainInfo> from(List<KeyChain> keyChains) {
             return keyChains.stream()
                     .map(keyChain -> KeyChainInfo.builder()

--- a/src/main/java/kr/husk/domain/keychain/entity/KeyChain.java
+++ b/src/main/java/kr/husk/domain/keychain/entity/KeyChain.java
@@ -32,4 +32,12 @@ public class KeyChain extends BaseEntity {
         this.name = name;
         this.content = content;
     }
+
+    public void changeName(String name) {
+        this.name = name;
+    }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/kr/husk/domain/keychain/exception/KeyChainExceptionCode.java
+++ b/src/main/java/kr/husk/domain/keychain/exception/KeyChainExceptionCode.java
@@ -1,0 +1,32 @@
+package kr.husk.domain.keychain.exception;
+
+import kr.husk.common.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+public enum KeyChainExceptionCode implements ExceptionCode {
+
+    KEY_CHAIN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 키체인입니다.");
+
+    HttpStatus httpStatus;
+    String cause;
+
+    KeyChainExceptionCode(HttpStatus httpStatus, String cause) {
+        this.httpStatus = httpStatus;
+        this.cause = cause;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCause() {
+        return cause;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/src/main/java/kr/husk/presentation/api/KeyChainApi.java
+++ b/src/main/java/kr/husk/presentation/api/KeyChainApi.java
@@ -40,7 +40,7 @@ public interface KeyChainApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "키체인 수정 완료",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = KeyChainDto.KeyChainInfo.class)
+                            schema = @Schema(implementation = KeyChainDto.Response.class)
                     )
             ),
             @ApiResponse(responseCode = "400", description = "키체인 수정 실패")

--- a/src/main/java/kr/husk/presentation/api/KeyChainApi.java
+++ b/src/main/java/kr/husk/presentation/api/KeyChainApi.java
@@ -29,10 +29,21 @@ public interface KeyChainApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "키체인 조회 완료",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = KeyChainDto.Response.class)
+                            schema = @Schema(implementation = KeyChainDto.KeyChainInfo.class)
                     )
             ),
             @ApiResponse(responseCode = "400", description = "키체인 조회 실패")
     })
     ResponseEntity<?> read(HttpServletRequest request);
+
+    @Operation(summary = "키체인 수정", description = "키체인 수정을 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "키체인 수정 완료",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = KeyChainDto.KeyChainInfo.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "키체인 수정 실패")
+    })
+    ResponseEntity<?> update(HttpServletRequest request, @RequestBody KeyChainDto.KeyChainInfo dto);
 }

--- a/src/main/java/kr/husk/presentation/rest/KeyChainController.java
+++ b/src/main/java/kr/husk/presentation/rest/KeyChainController.java
@@ -7,6 +7,7 @@ import kr.husk.presentation.api.KeyChainApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,5 +29,11 @@ public class KeyChainController implements KeyChainApi {
     @GetMapping("")
     public ResponseEntity<?> read(HttpServletRequest request) {
         return ResponseEntity.ok(keyChainService.read(request));
+    }
+
+    @Override
+    @PatchMapping("")
+    public ResponseEntity<?> update(HttpServletRequest request, KeyChainDto.KeyChainInfo dto) {
+        return ResponseEntity.ok(keyChainService.update(request, dto));
     }
 }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 사용자의 서비스 사용 편의성을 위한 키체인 수정 API 구현 필요
## Problem Solving

<!-- 해결 방법 -->
- 기존의 `KeyChainDto.KeyChainInfo` 클래스에 `content` 변수를 추가하여 API 요청 시 사용. (aa1b8338d9868c598b0e67053de6308f494c31b8)
- 수정된 키체인을 반영하기 위한 `Entity` 클래스 내의 `change` 관련 메소드 추가. (7149a7f7a72177a6061e9c4f96bacace797b291c)
- 문서화를 위한 swagger api 작성, controller 및 service 클래스 내 수정 관련 메소드 추가. (a506159737981e27f67f9e24a19ee4d16ba97110)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
<details>

<summary>API 테스트 결과</summary>

![image](https://github.com/user-attachments/assets/82f0ddac-5b57-4a88-8638-01c02941fe7d)

</details>