### PR TITLE
Feature(HK-115): 비밀번호 변경 플로우에 따른 추가 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/auth/dto/ChangePasswordDto.java
+++ b/src/main/java/kr/husk/application/auth/dto/ChangePasswordDto.java
@@ -12,11 +12,17 @@ public class ChangePasswordDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(name = "ChangePassword.Request", description = "사용자 비밀번호 재설정 요청 DTO")
-    public static class Request {
+    @Schema(name = "ChangePassword.CurrentPasswordRequest", description = "현재 비밀번호 확인 요청 DTO")
+    public static class CurrentPasswordRequest {
         @NotBlank(message = "현재 비밀번호 입력은 필수값입니다.")
         private String currentPassword;
+    }
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "ChangePassword.Request", description = "비밀번호 변경 요청 DTO")
+    public static class Request {
         @NotBlank(message = "새로운 비밀번호 입력은 필수값입니다.")
         @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()-_=+]).{8,16}$",
                 message = "비밀번호는 8자 이상 16자 이하이며, 숫자, 소문자, 대문자, 특수문자를 포함해야 합니다.")

--- a/src/main/java/kr/husk/domain/auth/exception/UserExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/UserExceptionCode.java
@@ -8,7 +8,8 @@ public enum UserExceptionCode implements ExceptionCode {
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
     EMAIL_IS_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 이메일입니다."),
     OAUTH_PASSWORD_CHANGE_DENIED(HttpStatus.FORBIDDEN, "OAuth 계정은 비밀번호를 변경할 수 없습니다."),
-    WITHDRAWN_USER(HttpStatus.FORBIDDEN, "이미 탈퇴한 계정입니다.");
+    WITHDRAWN_USER(HttpStatus.FORBIDDEN, "이미 탈퇴한 계정입니다."),
+    PASSWORD_MUST_BE_DIFFERENT(HttpStatus.BAD_REQUEST, "새로운 비밀번호는 현재 비밀번호와 달라야 합니다.");
 
     HttpStatus httpStatus;
     String cause;

--- a/src/main/java/kr/husk/presentation/api/AuthApi.java
+++ b/src/main/java/kr/husk/presentation/api/AuthApi.java
@@ -75,6 +75,13 @@ public interface AuthApi {
     })
     ResponseEntity<?> signOut(@RequestBody SignOutDto.Request dto, HttpServletRequest request);
 
+    @Operation(summary = "사용자 현재 비밀번호 확인 요청", description = "사용자의 현재 비밀번호를 확인하기 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "재설정 비밀번호 불일치")
+    })
+    ResponseEntity<?> verifyPassword(@Valid @RequestBody ChangePasswordDto.CurrentPasswordRequest dto, HttpServletRequest request);
+
     @Operation(summary = "사용자 비밀번호 재설정", description = "비밀번호 재설정을 위한 API")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),

--- a/src/main/java/kr/husk/presentation/rest/AuthController.java
+++ b/src/main/java/kr/husk/presentation/rest/AuthController.java
@@ -79,7 +79,13 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    @PatchMapping("/user")
+    @PostMapping("/password/verify")
+    public ResponseEntity<?> verifyPassword(ChangePasswordDto.CurrentPasswordRequest dto, HttpServletRequest request) {
+        return ResponseEntity.ok(authService.validateCurrentPassword(dto, request));
+    }
+
+    @Override
+    @PatchMapping("/users")
     public ResponseEntity<?> updatePassword(ChangePasswordDto.Request dto, HttpServletRequest request) {
         return ResponseEntity.ok(authService.changePassword(dto, request));
     }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 비밀번호 변경 플로우에 따른 추가 API 구현
  - `회원정보 수정(비밀번호 변경) 요청` → `현재 비밀번호 확인` → `새로운 비밀번호 및 새로운 비밀번호 확인`
- 위의 플로우에 따른 `현재 비밀번호 확인` API 필요성 확인.
- API 추가 구현으로 인한 역할 분리
  - 기존: `비밀번호 변경 요청` → `현재 비밀번호 및 변경 비밀번호 동시 검증` → `비밀번호 변경`
  - 현재: `비밀번호 변경 요청` → `현재 비밀번호 검증` → `변경 비밀번호 검증` → `비밀번호 변경` (별도로 분할하여 확인)

## Problem Solving

<!-- 해결 방법 -->
- 역할 분리에 따른 dto 객체 분리 (3fdd5001ca306b544c2f4d58c35d363533102f36)
- 별도의 API 및 비즈니스 로직 추가 (761493800473f1d5ff8dcb2d149985122172189c)
- 추가적으로 WAS에서도 현재 비밀번호와 변경할 비밀번호가 일치할 경우에 대한 예외 추가 및 예외 코드 추가(7ca8292151ef42b8997ea4d6cbc0694e65c7acf4)


## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 얘기 나눴던대로 구현하였습니다. API에 대한 명세는 기존처럼 `swagger` 확인하시면 될 것 같습니다.
- 추후에 **질문사항, 필요하신 요구사항** 있으시면 코멘트나 스크럼 또는 연락주세요!
<details>

<summary>API 테스트</summary>

- 입력한 현재 비밀번호가 일치하지 않음
![image](https://github.com/user-attachments/assets/5709bdf8-6d63-48c3-8220-22d09f02c579)
- 입력한 현재 비밀번호가 일치함
![image](https://github.com/user-attachments/assets/6d481617-18a2-4790-ac13-ffb4066d8477)
- 현재 비밀번호화 변경할 비밀번호가 일치함
![image](https://github.com/user-attachments/assets/0194df64-86fb-49bd-bdcf-dc3cade29972)


</details>