### PR TITLE
Feature(HK-111): 키체인 삭제를 위한 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
+++ b/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
@@ -57,6 +57,7 @@ public class KeyChainDto {
 
         public static List<KeyChainInfo> from(List<KeyChain> keyChains) {
             return keyChains.stream()
+                    .filter(keyChain -> keyChain.isDeleted() == false)
                     .map(keyChain -> KeyChainInfo.builder()
                             .id(keyChain.getId())
                             .name(keyChain.getName())

--- a/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
+++ b/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
@@ -86,7 +86,7 @@ public class KeyChainService {
         }
 
         KeyChain keyChain = keyChainRepository.findById(id).get();
-        if (keyChain == null) {
+        if (keyChain == null || keyChain.isDeleted()) {
             throw new GlobalException(KeyChainExceptionCode.KEY_CHAIN_NOT_FOUND);
         }
 

--- a/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
+++ b/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
@@ -78,4 +78,23 @@ public class KeyChainService {
         return KeyChainDto.Response.of("키체인 수정이 완료되었습니다.");
     }
 
+    public KeyChainDto.Response delete(HttpServletRequest request, Long id) {
+        String accessToken = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(accessToken);
+        if (!jwtProvider.validateToken(accessToken)) {
+            throw new GlobalException(AuthExceptionCode.INVALID_ACCESS_TOKEN);
+        }
+
+        KeyChain keyChain = keyChainRepository.findById(id).get();
+        if (keyChain == null) {
+            throw new GlobalException(KeyChainExceptionCode.KEY_CHAIN_NOT_FOUND);
+        }
+
+        keyChain.delete();
+        keyChainRepository.save(keyChain);
+        log.info("사용자 {}의 {}번 키체인이 삭제되었습니다.", email, id);
+
+        return KeyChainDto.Response.of("키체인 삭제가 완료되었습니다.");
+    }
+
 }

--- a/src/main/java/kr/husk/presentation/api/KeyChainApi.java
+++ b/src/main/java/kr/husk/presentation/api/KeyChainApi.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import kr.husk.application.keychain.dto.KeyChainDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "[키체인 관련 API]", description = "키체인(키페어) 관련 API")
@@ -46,4 +47,15 @@ public interface KeyChainApi {
             @ApiResponse(responseCode = "400", description = "키체인 수정 실패")
     })
     ResponseEntity<?> update(HttpServletRequest request, @RequestBody KeyChainDto.KeyChainInfo dto);
+
+    @Operation(summary = "키체인 삭제", description = "키체인 삭제를 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "키체인 삭제 완료",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = KeyChainDto.Response.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "키체인 삭제 실패")
+    })
+    ResponseEntity<?> delete(HttpServletRequest request, @PathVariable Long id);
 }

--- a/src/main/java/kr/husk/presentation/rest/KeyChainController.java
+++ b/src/main/java/kr/husk/presentation/rest/KeyChainController.java
@@ -36,4 +36,10 @@ public class KeyChainController implements KeyChainApi {
     public ResponseEntity<?> update(HttpServletRequest request, KeyChainDto.KeyChainInfo dto) {
         return ResponseEntity.ok(keyChainService.update(request, dto));
     }
+
+    @Override
+    @PatchMapping("/{id}")
+    public ResponseEntity<?> delete(HttpServletRequest request, Long id) {
+        return ResponseEntity.ok(keyChainService.delete(request, id));
+    }
 }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 서비스 기능 중 사용자가 등록한 키체인을 삭제하는 API 필요.
- 데이터 복구 및 무결성 유지를 위한 `soft delete`

## Problem Solving

<!-- 해결 방법 -->
- `Controller` 및 `Service` 계층에 비즈니스 로직 구현 (6f6e75b12ec85930474c8872a03d7d431ef8809f)
- `키체인 조회 API` 요청 시 삭제된 키체인을 필터링하여 삭제되지 않은 키체인만 반환하도록 함. (84c59597d8773714dbb159f9cfa0e40b7570ba72)
## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
<details>
<summary>API 테스트</summary>

- 삭제 완료
![image](https://github.com/user-attachments/assets/e2c4d233-369d-4780-8b93-58e009574a21)

- 삭제 중복 요청
![image](https://github.com/user-attachments/assets/c1fbe1c1-09b1-47e9-ae92-3d0ecf97af2b)

- 1번 키페어 삭제 시 키페어 조회 요청에 대한 응답
![image](https://github.com/user-attachments/assets/4acd631c-c192-46bf-93f3-9b5a9ef3097c)

</details>