### PR TITLE
Feature(HK-114): 키체인 content 복호화를 위한 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
+++ b/src/main/java/kr/husk/application/keychain/dto/KeyChainDto.java
@@ -2,6 +2,7 @@ package kr.husk.application.keychain.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import kr.husk.common.service.EncryptionService;
 import kr.husk.domain.keychain.entity.KeyChain;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -63,6 +64,14 @@ public class KeyChainDto {
                             .name(keyChain.getName())
                             .build())
                     .collect(Collectors.toUnmodifiableList());
+        }
+
+        public static KeyChainInfo from(KeyChain keyChain, EncryptionService encryptionService) {
+            return KeyChainInfo.builder()
+                    .id(keyChain.getId())
+                    .name(keyChain.getName())
+                    .content(encryptionService.decrypt(keyChain.getContent()))
+                    .build();
         }
     }
 }

--- a/src/main/java/kr/husk/common/service/EncryptionService.java
+++ b/src/main/java/kr/husk/common/service/EncryptionService.java
@@ -19,4 +19,9 @@ public class EncryptionService {
         return Base64.getEncoder().encodeToString(encryptedBytes);
     }
 
+    public String decrypt(String encryptedValue) {
+        byte[] encryptedBytes = Base64.getDecoder().decode(encryptedValue);
+        byte[] decryptedBytes = bytesEncryptor.decrypt(encryptedBytes);
+        return new String(decryptedBytes, StandardCharsets.UTF_8);
+    }
 }

--- a/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
+++ b/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
@@ -97,4 +97,17 @@ public class KeyChainService {
         return KeyChainDto.Response.of("키체인 삭제가 완료되었습니다.");
     }
 
+    public KeyChainDto.KeyChainInfo decrypt(HttpServletRequest request, Long id) {
+        String accessToken = jwtProvider.resolveToken(request);
+        if (!jwtProvider.validateToken(accessToken)) {
+            throw new GlobalException(AuthExceptionCode.INVALID_ACCESS_TOKEN);
+        }
+
+        KeyChain keyChain = keyChainRepository.findById(id).get();
+        if (keyChain == null || keyChain.isDeleted()) {
+            throw new GlobalException(KeyChainExceptionCode.KEY_CHAIN_NOT_FOUND);
+        }
+
+        return KeyChainDto.KeyChainInfo.from(keyChain, encryptionService);
+    }
 }

--- a/src/main/java/kr/husk/presentation/api/KeyChainApi.java
+++ b/src/main/java/kr/husk/presentation/api/KeyChainApi.java
@@ -58,4 +58,15 @@ public interface KeyChainApi {
             @ApiResponse(responseCode = "400", description = "키체인 삭제 실패")
     })
     ResponseEntity<?> delete(HttpServletRequest request, @PathVariable Long id);
+
+    @Operation(summary = "키체인 암호 복호화", description = "키체인 암호 복호화를 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "키체인 복호화 완료",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = KeyChainDto.Response.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "키체인 복호화 실패")
+    })
+    ResponseEntity<?> decryptContent(HttpServletRequest request, @PathVariable Long id);
 }

--- a/src/main/java/kr/husk/presentation/rest/KeyChainController.java
+++ b/src/main/java/kr/husk/presentation/rest/KeyChainController.java
@@ -42,4 +42,10 @@ public class KeyChainController implements KeyChainApi {
     public ResponseEntity<?> delete(HttpServletRequest request, Long id) {
         return ResponseEntity.ok(keyChainService.delete(request, id));
     }
+
+    @Override
+    @GetMapping("/{id}/decrypt")
+    public ResponseEntity<?> decryptContent(HttpServletRequest request, Long id) {
+        return ResponseEntity.ok(keyChainService.decrypt(request, id));
+    }
 }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- `keychain` `content` 확인 로직
  - `keychain` 조회를 통해 사용자가 `dashboard` 진입 시 자신이 등록한 `keychain` 확인 가능.
  - 사용자가 등록한 `keychain`을 클릭하여 확인하여도 content는 `******` 와 같이 마스킹됨.
- `keychain`의 `content`를 확인하기 위한 API 필요
## Problem Solving

<!-- 해결 방법 -->
- 복호화를 위한 `decrypt()` 추가 (77c578096c7e266d88f9c8d97c2f9af58c3a0a96)
- 복호화 된 `keychain` 반환을 위한 dto 메소드 추가 (ec16d6cef936c0e22b6d50080e223525f3facea8)
- 복호화 API 구현 (05928e2ff61a76eff8b93725afe144935d0f4bf2)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
<details>

<summary>API 테스트</summary>

- DB에 저장된 값
![image](https://github.com/user-attachments/assets/ccb5c376-e5ae-4f65-8478-04309799b485)

- 복호화 요청 결과
![image](https://github.com/user-attachments/assets/d983e66a-ac6d-4f5e-8045-01177e6017a9)

</details>