### PR TITLE
Feature(HK-107): 커넥션 저장을 위한 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/connection/dto/ConnectionInfoDto.java
+++ b/src/main/java/kr/husk/application/connection/dto/ConnectionInfoDto.java
@@ -1,0 +1,46 @@
+package kr.husk.application.connection.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.husk.domain.auth.entity.User;
+import kr.husk.domain.connection.entity.Connection;
+import kr.husk.domain.keychain.entity.KeyChain;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ConnectionInfoDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "ConnectionInfo.Request", description = "SSH 커넥션 저장 요청 DTO")
+    public static class Request {
+        private String name;
+        private String host;
+        private String username;
+        private String port;
+        private String keyChainName;
+
+        public Connection toEntity(User user, KeyChain keyChain) {
+            return Connection.builder()
+                    .user(user)
+                    .keyChain(keyChain)
+                    .name(name)
+                    .host(host)
+                    .username(username)
+                    .port(port)
+                    .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Schema(name = "ConnectionInfo.Response", description = "SSH 커넥션 저장 요청에 대한 응답 DTO")
+    public static class Response {
+        private String message;
+
+        public static Response of(String message) {
+            return new Response(message);
+        }
+    }
+}

--- a/src/main/java/kr/husk/domain/connection/repository/ConnectionRepository.java
+++ b/src/main/java/kr/husk/domain/connection/repository/ConnectionRepository.java
@@ -1,0 +1,7 @@
+package kr.husk.domain.connection.repository;
+
+import kr.husk.domain.connection.entity.Connection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConnectionRepository extends JpaRepository<Connection, Long> {
+}

--- a/src/main/java/kr/husk/domain/connection/service/ConnectionService.java
+++ b/src/main/java/kr/husk/domain/connection/service/ConnectionService.java
@@ -1,0 +1,50 @@
+package kr.husk.domain.connection.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.husk.application.connection.dto.ConnectionInfoDto;
+import kr.husk.common.exception.GlobalException;
+import kr.husk.common.jwt.util.JwtProvider;
+import kr.husk.domain.auth.entity.User;
+import kr.husk.domain.auth.exception.AuthExceptionCode;
+import kr.husk.domain.auth.service.UserService;
+import kr.husk.domain.connection.entity.Connection;
+import kr.husk.domain.connection.repository.ConnectionRepository;
+import kr.husk.domain.keychain.entity.KeyChain;
+import kr.husk.domain.keychain.exception.KeyChainExceptionCode;
+import kr.husk.domain.keychain.service.KeyChainService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConnectionService {
+
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
+    private final KeyChainService keyChainService;
+    private final ConnectionRepository connectionRepository;
+
+    public ConnectionInfoDto.Response create(HttpServletRequest request, ConnectionInfoDto.Request dto) {
+        String accessToken = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(accessToken);
+
+        if (!jwtProvider.validateToken(accessToken)) {
+            throw new GlobalException(AuthExceptionCode.INVALID_ACCESS_TOKEN);
+        }
+
+        User user = userService.read(email);
+        KeyChain keyChain = keyChainService.read(user, dto.getKeyChainName());
+
+        if (keyChain == null) {
+            throw new GlobalException(KeyChainExceptionCode.KEY_CHAIN_NOT_FOUND);
+        }
+
+        log.info("사용자 {}의 커넥션 {}이 저장되었습니다.", email, dto.getName());
+        Connection connection = dto.toEntity(user, keyChain);
+        connectionRepository.save(connection);
+
+        return ConnectionInfoDto.Response.of("SSH 커넥션이 성공적으로 저장되었습니다.");
+    }
+}

--- a/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
+++ b/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
@@ -58,6 +58,16 @@ public class KeyChainService {
         return KeyChainDto.KeyChainInfo.from(user.getKeyChains());
     }
 
+    public KeyChain read(User user, String name) {
+        List<KeyChain> keyChainList = user.getKeyChains();
+        for (KeyChain keyChain : keyChainList) {
+            if (keyChain.getName().equals(name)) {
+                return keyChain;
+            }
+        }
+        return null;
+    }
+
     public KeyChainDto.Response update(HttpServletRequest request, KeyChainDto.KeyChainInfo dto) {
         String accessToken = jwtProvider.resolveToken(request);
         String email = jwtProvider.getEmail(accessToken);

--- a/src/main/java/kr/husk/presentation/api/ConnectionApi.java
+++ b/src/main/java/kr/husk/presentation/api/ConnectionApi.java
@@ -1,0 +1,26 @@
+package kr.husk.presentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import kr.husk.application.connection.dto.ConnectionInfoDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "[커넥션 관련 API]", description = "사용자 SSH 커넥션 관련 API")
+public interface ConnectionApi {
+
+    @Operation(summary = "SSH 커넥션 저장", description = "SSH 접속을 위한 커넥션 정보 저장 요청 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "SSH 커넥션 저장 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ConnectionInfoDto.Response.class))),
+            @ApiResponse(responseCode = "400", description = "SSH 커넥션 저장 실패")
+    })
+    ResponseEntity<?> create(HttpServletRequest request, @RequestBody ConnectionInfoDto.Request dto);
+
+}

--- a/src/main/java/kr/husk/presentation/rest/ConnectionController.java
+++ b/src/main/java/kr/husk/presentation/rest/ConnectionController.java
@@ -1,0 +1,25 @@
+package kr.husk.presentation.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kr.husk.application.connection.dto.ConnectionInfoDto;
+import kr.husk.domain.connection.service.ConnectionService;
+import kr.husk.presentation.api.ConnectionApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/connections")
+public class ConnectionController implements ConnectionApi {
+
+    private final ConnectionService connectionService;
+
+    @Override
+    @PostMapping("")
+    public ResponseEntity<?> create(HttpServletRequest request, ConnectionInfoDto.Request dto) {
+        return ResponseEntity.ok(connectionService.create(request, dto));
+    }
+}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 사용자의 `keychain`을 통해 SSH 접속을 위한 `connection` 저장 API 필요.
- 저장된 `connection`을 통해서 사용자는 편리하게 SSH 접속이 가능.

## Problem Solving

<!-- 해결 방법 -->
- `SSH` 접속에 필요한 정보를 `DB`에 저장.
- 관련 `controller` 구현(cb9f7ba0ebf723a828d87f46c38a588ed9aba9ec) 및 `service` 내에 비즈니스 로직 구현(53c725b330de21870e4f42ec40a3c01f91fe45af)
- 기존에 `keychain`의 `content`를 입력하는 부분을 `keychain`의 `name` 입력하는 것으로 변경.
  - 사용자는 `connection`을 생성하기 전 `keychain`을 미리 저장하여야 하는 것으로 함.
  - 하지만 UX 관점에서 좋지 않다고 생각이 되어 향후 **_수정_** 될 수 있을 듯 합니다.

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
<details>

<summary>API 테스트 결과</summary>

![스크린샷 2025-03-11 192339](https://github.com/user-attachments/assets/ce99c31c-dc68-4c8b-bcbd-504aa9a31da9)
![스크린샷 2025-03-11 192430](https://github.com/user-attachments/assets/94ee07d8-2cc5-4d15-94cc-48cceba373fb)

</details>


- 오타가 있으면 말씀해주시면 감사하겠습니다. :)
- 궁금한 내용이 있다면 편하게 질문해주세요!