### PR TITLE
Feature(HK-123): 사용자 Connection 조회 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/connection/dto/ConnectionInfoDto.java
+++ b/src/main/java/kr/husk/application/connection/dto/ConnectionInfoDto.java
@@ -5,8 +5,12 @@ import kr.husk.domain.auth.entity.User;
 import kr.husk.domain.connection.entity.Connection;
 import kr.husk.domain.keychain.entity.KeyChain;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ConnectionInfoDto {
 
@@ -41,6 +45,34 @@ public class ConnectionInfoDto {
 
         public static Response of(String message) {
             return new Response(message);
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(name = "ConnectionInfo.Summary", description = "SSH 커넥션 조회에 대한 단순 정보 응답 DTO")
+    public static class Summary {
+        private Long id;
+        private String name;
+        private String host;
+        private String port;
+
+        public static List<Summary> from(List<Connection> connections) {
+            return connections.stream()
+                    .filter(connection -> connection.isDeleted() == false)
+                    .map(connection -> Summary.builder()
+                            .id(connection.getId())
+                            .name(connection.getName())
+                            .host(masking(connection.getHost()))
+                            .port(connection.getPort())
+                            .build())
+                    .collect(Collectors.toUnmodifiableList());
+        }
+
+        private static String masking(String host) {
+            String[] parts = host.split("\\.");
+            return parts[0] + "." + parts[1] + ".*.*";
         }
     }
 }

--- a/src/main/java/kr/husk/domain/connection/entity/Connection.java
+++ b/src/main/java/kr/husk/domain/connection/entity/Connection.java
@@ -1,6 +1,11 @@
 package kr.husk.domain.connection.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import kr.husk.common.entity.BaseEntity;
 import kr.husk.domain.auth.entity.User;
 import kr.husk.domain.keychain.entity.KeyChain;
@@ -45,5 +50,17 @@ public class Connection extends BaseEntity {
         this.host = host;
         this.username = username;
         this.port = port;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public String getPort() {
+        return port;
     }
 }

--- a/src/main/java/kr/husk/domain/connection/service/ConnectionService.java
+++ b/src/main/java/kr/husk/domain/connection/service/ConnectionService.java
@@ -16,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -46,5 +48,17 @@ public class ConnectionService {
         connectionRepository.save(connection);
 
         return ConnectionInfoDto.Response.of("SSH 커넥션이 성공적으로 저장되었습니다.");
+    }
+
+    public List<ConnectionInfoDto.Summary> read(HttpServletRequest request) {
+        String accessToken = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(accessToken);
+
+        if (!jwtProvider.validateToken(accessToken)) {
+            throw new GlobalException(AuthExceptionCode.INVALID_ACCESS_TOKEN);
+        }
+
+        User user = userService.read(email);
+        return ConnectionInfoDto.Summary.from(user.getConnections());
     }
 }

--- a/src/main/java/kr/husk/presentation/api/ConnectionApi.java
+++ b/src/main/java/kr/husk/presentation/api/ConnectionApi.java
@@ -23,4 +23,13 @@ public interface ConnectionApi {
     })
     ResponseEntity<?> create(HttpServletRequest request, @RequestBody ConnectionInfoDto.Request dto);
 
+    @Operation(summary = "SSH 커넥션 조회", description = "SSH 커넥션 조회 요청 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "SSH 커넥션 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ConnectionInfoDto.Summary.class))),
+            @ApiResponse(responseCode = "400", description = "SSH 커넥션 조회 실패")
+    })
+    ResponseEntity<?> read(HttpServletRequest request);
+
 }

--- a/src/main/java/kr/husk/presentation/rest/ConnectionController.java
+++ b/src/main/java/kr/husk/presentation/rest/ConnectionController.java
@@ -6,6 +6,7 @@ import kr.husk.domain.connection.service.ConnectionService;
 import kr.husk.presentation.api.ConnectionApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,4 +23,11 @@ public class ConnectionController implements ConnectionApi {
     public ResponseEntity<?> create(HttpServletRequest request, ConnectionInfoDto.Request dto) {
         return ResponseEntity.ok(connectionService.create(request, dto));
     }
+
+    @Override
+    @GetMapping("")
+    public ResponseEntity<?> read(HttpServletRequest request) {
+        return ResponseEntity.ok(connectionService.read(request));
+    }
+
 }


### PR DESCRIPTION
## Motivation
<!-- 작성 배경 -->
- 서비스 사용자 `DashBoard` 진입 시 `Connection` 접속을 위한 `Connection 조회 API` 구현 필요.
- 사용자가 자신의 `Connection`을 쉽게 조회 및 관리하기 위함.

## Problem Solving
<!-- 해결 방법 -->
- `DTO` 구현을 위한 Entity의 `getter` 메소드 추가 (0c7c9972097beaab2b76a1ab62d187b9818a1e1a)
- `Connection` 조회에 대한 `DTO` 구현 (9103d7f49a1c574016edd43ebf86a29d8d1265e9)
- 컨트롤러(05f7e1cc30451609c48019fb55c6d0fc2f55160c) 및 비즈니스 로직 구현(74e9f22ecbdc93621a19c025cf5921c0fae62bf0)

## To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 궁금한 부분이나 오타 있으면 말씀해주세요 :)
<details>

<summary>API 테스트 결과</summary>

![스크린샷 2025-03-12 034251](https://github.com/user-attachments/assets/486de854-5186-401d-8333-54410964c37b)

</details>