### PR TITLE
Chore(HK-132): 커넥션 접속을 위한 WebSocket 및 JSch 사전 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,12 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-orgjson', version: '0.11.2'
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.30.1'
+
+    // Web Socket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // SSH Connection
+    implementation 'com.jcraft:jsch:0.1.55'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/husk/infrastructure/config/WebSocketConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/WebSocketConfig.java
@@ -1,0 +1,22 @@
+package kr.husk.infrastructure.config;
+
+import kr.husk.infrastructure.websocket.SshWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final SshWebSocketHandler sshWebSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(sshWebSocketHandler, "/ws/ssh-terminal")
+                .setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/kr/husk/infrastructure/websocket/SshWebSocketHandler.java
+++ b/src/main/java/kr/husk/infrastructure/websocket/SshWebSocketHandler.java
@@ -1,11 +1,8 @@
 package kr.husk.infrastructure.websocket;
 
 import com.jcraft.jsch.ChannelShell;
-import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.Session;
-import kr.husk.domain.connection.entity.Connection;
 import kr.husk.domain.connection.service.ConnectionService;
-import kr.husk.domain.keychain.entity.KeyChain;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,7 +11,6 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -63,39 +59,39 @@ public class SshWebSocketHandler extends TextWebSocketHandler {
     }
 
     private void connectToSsh(WebSocketSession webSocketSession, Long connectionId) throws Exception {
-        Connection connection = connectionService.read(connectionId);
-        KeyChain keyChain = connection.getKeyChain();
-
-        JSch jsch = new JSch();
-        byte[] privateKeyBytes = keyChain.getContent().getBytes(StandardCharsets.UTF_8);
-        jsch.addIdentity(connection.getUsername(), privateKeyBytes, null, null);
-
-        Session sshSession = jsch.getSession(connection.getUsername(), connection.getHost(), Integer.parseInt(connection.getPort()));
-        sshSession.setConfig("StrictHostKeyChecking", "no");
-        sshSession.connect();
-
-        ChannelShell channel = (ChannelShell) sshSession.openChannel("shell");
-        channel.setPty(true);
-        InputStream inputStream = channel.getInputStream();
-        OutputStream outputStream = channel.getOutputStream();
-        channel.connect();
-
-        sshSessions.put(webSocketSession, sshSession);
-        sshChannels.put(webSocketSession, channel);
-
-        new Thread(() -> {
-            try {
-                byte[] buffer = new byte[1024];
-                int read;
-                while ((read = inputStream.read(buffer)) != -1) {
-                    webSocketSession.sendMessage(new TextMessage(new String(buffer, 0, read, StandardCharsets.UTF_8)));
-                }
-            } catch (Exception e) {
-                log.error("SSH 출력 읽기 중 오류 발생", e);
-            }
-        }).start();
-
-        log.info("SSH 세션이 생성되었습니다: {}", sshSession);
+//        Connection connection = connectionService.read(connectionId);
+//        KeyChain keyChain = connection.getKeyChain();
+//
+//        JSch jsch = new JSch();
+//        byte[] privateKeyBytes = keyChain.getContent().getBytes(StandardCharsets.UTF_8);
+//        jsch.addIdentity(connection.getUsername(), privateKeyBytes, null, null);
+//
+//        Session sshSession = jsch.getSession(connection.getUsername(), connection.getHost(), Integer.parseInt(connection.getPort()));
+//        sshSession.setConfig("StrictHostKeyChecking", "no");
+//        sshSession.connect();
+//
+//        ChannelShell channel = (ChannelShell) sshSession.openChannel("shell");
+//        channel.setPty(true);
+//        InputStream inputStream = channel.getInputStream();
+//        OutputStream outputStream = channel.getOutputStream();
+//        channel.connect();
+//
+//        sshSessions.put(webSocketSession, sshSession);
+//        sshChannels.put(webSocketSession, channel);
+//
+//        new Thread(() -> {
+//            try {
+//                byte[] buffer = new byte[1024];
+//                int read;
+//                while ((read = inputStream.read(buffer)) != -1) {
+//                    webSocketSession.sendMessage(new TextMessage(new String(buffer, 0, read, StandardCharsets.UTF_8)));
+//                }
+//            } catch (Exception e) {
+//                log.error("SSH 출력 읽기 중 오류 발생", e);
+//            }
+//        }).start();
+//
+//        log.info("SSH 세션이 생성되었습니다: {}", sshSession);
     }
 
     private void sendCommandToSsh(WebSocketSession webSocketSession, String command) throws Exception {

--- a/src/main/java/kr/husk/infrastructure/websocket/SshWebSocketHandler.java
+++ b/src/main/java/kr/husk/infrastructure/websocket/SshWebSocketHandler.java
@@ -1,0 +1,112 @@
+package kr.husk.infrastructure.websocket;
+
+import com.jcraft.jsch.ChannelShell;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.Session;
+import kr.husk.domain.connection.entity.Connection;
+import kr.husk.domain.connection.service.ConnectionService;
+import kr.husk.domain.keychain.entity.KeyChain;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SshWebSocketHandler extends TextWebSocketHandler {
+
+    private final ConnectionService connectionService;
+
+    private final Map<WebSocketSession, ChannelShell> sshChannels = new HashMap<>();
+    private final Map<WebSocketSession, Session> sshSessions = new HashMap<>();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        log.info("Web Socket 연결이 완료되었습니다. {}", session.getId());
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String payload = message.getPayload();
+        log.info("받은 메시지: {}", payload);
+
+        if (payload.startsWith("connect:")) {
+            Long connectionId = Long.parseLong(payload.split(":")[1]);
+            connectToSsh(session, connectionId);
+        } else {
+            sendCommandToSsh(session, payload);
+        }
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        log.info("WebSocket 연결이 닫혔습니다: {}", session.getId());
+        ChannelShell sshChannel = sshChannels.remove(session);
+        if (sshChannel != null && sshChannel.isConnected()) {
+            sshChannel.disconnect();
+        }
+
+        Session sshSession = sshSessions.remove(session);
+        if (sshSession != null && sshSession.isConnected()) {
+            sshSession.disconnect();
+        }
+    }
+
+    private void connectToSsh(WebSocketSession webSocketSession, Long connectionId) throws Exception {
+        Connection connection = connectionService.read(connectionId);
+        KeyChain keyChain = connection.getKeyChain();
+
+        JSch jsch = new JSch();
+        byte[] privateKeyBytes = keyChain.getContent().getBytes(StandardCharsets.UTF_8);
+        jsch.addIdentity(connection.getUsername(), privateKeyBytes, null, null);
+
+        Session sshSession = jsch.getSession(connection.getUsername(), connection.getHost(), Integer.parseInt(connection.getPort()));
+        sshSession.setConfig("StrictHostKeyChecking", "no");
+        sshSession.connect();
+
+        ChannelShell channel = (ChannelShell) sshSession.openChannel("shell");
+        channel.setPty(true);
+        InputStream inputStream = channel.getInputStream();
+        OutputStream outputStream = channel.getOutputStream();
+        channel.connect();
+
+        sshSessions.put(webSocketSession, sshSession);
+        sshChannels.put(webSocketSession, channel);
+
+        new Thread(() -> {
+            try {
+                byte[] buffer = new byte[1024];
+                int read;
+                while ((read = inputStream.read(buffer)) != -1) {
+                    webSocketSession.sendMessage(new TextMessage(new String(buffer, 0, read, StandardCharsets.UTF_8)));
+                }
+            } catch (Exception e) {
+                log.error("SSH 출력 읽기 중 오류 발생", e);
+            }
+        }).start();
+
+        log.info("SSH 세션이 생성되었습니다: {}", sshSession);
+    }
+
+    private void sendCommandToSsh(WebSocketSession webSocketSession, String command) throws Exception {
+        ChannelShell channel = sshChannels.get(webSocketSession);
+        if (channel == null || !channel.isConnected()) {
+            webSocketSession.sendMessage(new TextMessage("Error: SSH session is not connected."));
+            return;
+        }
+
+        OutputStream outputStream = channel.getOutputStream();
+        outputStream.write((command + "\n").getBytes(StandardCharsets.UTF_8));
+        outputStream.flush();
+    }
+}


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 웹 터미널을 통한 커넥션 접속을 위해 WebSocket 설정 필요.
- 대화형 웹 터미널을 위한 WebSocket 필요.
- 커넥션 접속을 위한 JSch를 이용한 WebSocket Handler 구현.

## Problem Solving

<!-- 해결 방법 -->
- JSch 및 WebSocket 사용을 위한 의존성 주입(f2875afb7ae24e4abed36933321845cc0361c54a)
- WebSocket 설정 파일 작성(70d7dee31d75d3255e394e9c0be834a2ed151335)
- WebSocket Handler 구현(12304d89f77c7c2a8ead9aa5a7fc4edbe36421b5)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- Handler에 구현된 부분에서 CI failed가 발생했었는데 이는 미리 작성해둔 코드가 있었는데 해당 PR에는 그 코드가 반영되지 않아서 오류가 발생한 것 입니다!
  - PR이 커져서 분리하다보니 해당 부분을 놓쳤네요..😅
- 다음 PR에 올릴 예정이며, 현재는 주석 처리하여 CI 성공했습니다.  