### PR TITLE
Feature(HK-108): 커넥션 접속 요청 API 구현

### DIFF
--- a/src/main/java/kr/husk/domain/connection/entity/Connection.java
+++ b/src/main/java/kr/husk/domain/connection/entity/Connection.java
@@ -11,11 +11,13 @@ import kr.husk.domain.auth.entity.User;
 import kr.husk.domain.keychain.entity.KeyChain;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 @Entity(name = "connection")
+@Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Connection extends BaseEntity {
@@ -50,17 +52,5 @@ public class Connection extends BaseEntity {
         this.host = host;
         this.username = username;
         this.port = port;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getHost() {
-        return host;
-    }
-
-    public String getPort() {
-        return port;
     }
 }

--- a/src/main/java/kr/husk/domain/connection/exception/ConnectionExceptionCode.java
+++ b/src/main/java/kr/husk/domain/connection/exception/ConnectionExceptionCode.java
@@ -1,0 +1,32 @@
+package kr.husk.domain.connection.exception;
+
+import kr.husk.common.exception.ExceptionCode;
+import org.springframework.http.HttpStatus;
+
+public enum ConnectionExceptionCode implements ExceptionCode {
+
+    CONNECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 커넥션이 존재하지 않습니다.");
+
+    HttpStatus httpStatus;
+    String cause;
+
+    ConnectionExceptionCode(HttpStatus httpStatus, String cause) {
+        this.httpStatus = httpStatus;
+        this.cause = cause;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCause() {
+        return cause;
+    }
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/src/main/java/kr/husk/domain/connection/service/ConnectionService.java
+++ b/src/main/java/kr/husk/domain/connection/service/ConnectionService.java
@@ -8,6 +8,7 @@ import kr.husk.domain.auth.entity.User;
 import kr.husk.domain.auth.exception.AuthExceptionCode;
 import kr.husk.domain.auth.service.UserService;
 import kr.husk.domain.connection.entity.Connection;
+import kr.husk.domain.connection.exception.ConnectionExceptionCode;
 import kr.husk.domain.connection.repository.ConnectionRepository;
 import kr.husk.domain.keychain.entity.KeyChain;
 import kr.husk.domain.keychain.exception.KeyChainExceptionCode;
@@ -60,5 +61,23 @@ public class ConnectionService {
 
         User user = userService.read(email);
         return ConnectionInfoDto.Summary.from(user.getConnections());
+    }
+
+    public Connection read(Long id) {
+        return connectionRepository.findById(id)
+                .orElseThrow(() -> new GlobalException(ConnectionExceptionCode.CONNECTION_NOT_FOUND));
+    }
+
+    public ConnectionInfoDto.Response connect(HttpServletRequest request, Long id) {
+        String accessToken = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(accessToken);
+
+        if (!jwtProvider.validateToken(accessToken)) {
+            throw new GlobalException(AuthExceptionCode.INVALID_ACCESS_TOKEN);
+        }
+
+        Connection connection = read(id);
+
+        return ConnectionInfoDto.Response.of("커넥션 접속에 성공하였습니다.");
     }
 }

--- a/src/main/java/kr/husk/presentation/api/ConnectionApi.java
+++ b/src/main/java/kr/husk/presentation/api/ConnectionApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import kr.husk.application.connection.dto.ConnectionInfoDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "[커넥션 관련 API]", description = "사용자 SSH 커넥션 관련 API")
@@ -32,4 +33,12 @@ public interface ConnectionApi {
     })
     ResponseEntity<?> read(HttpServletRequest request);
 
+    @Operation(summary = "커넥션 접속 요청", description = "커넥션 접속 요청을 위한 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "커넥션 접속 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ConnectionInfoDto.Response.class))),
+            @ApiResponse(responseCode = "400", description = "커넥션 접속 실패")
+    })
+    ResponseEntity<?> connect(HttpServletRequest request, @PathVariable Long id);
 }

--- a/src/main/java/kr/husk/presentation/rest/ConnectionController.java
+++ b/src/main/java/kr/husk/presentation/rest/ConnectionController.java
@@ -30,4 +30,10 @@ public class ConnectionController implements ConnectionApi {
         return ResponseEntity.ok(connectionService.read(request));
     }
 
+    @Override
+    @PostMapping("/{id}/ssh-session")
+    public ResponseEntity<?> connect(HttpServletRequest request, Long id) {
+        return ResponseEntity.ok(connectionService.connect(request, id));
+    }
+
 }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 서비스 핵심 기능 이용을 위해서 사용자가 등록한 커넥션을 접속하기 위한 요청 API 필요.
- 대화형 웹 터미널 기능 이용을 위한 WebSocket을 활용한 핸들러 메소드 필요.

## Problem Solving

<!-- 해결 방법 -->
- JSch 및 WebSocket을 활용한 핸들러 구현(8a5bfcdafd22501253577032b608f956afb992de)
- 서비스 비즈니스 로직 구현(7abd087e9acb28ceeeb5e5b94b4c5a9504ab462e) 및 관련 예외 코드 추가(625ab01a5bcbcae4d3702a82adeeec470f6c433a)
- `Connection` Entity에서 getter 메소드 필요로 인해 `get{필드}()` 형식의 메소드를 만들었으나 어노테이션으로 변경(7c448432c64f4d9a2494f931a34e5dc88963df88)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 대화형 웹 터미널을 위해선 웹 소켓 통신이 필수라고 합니다. 
  - 해당 API 연동할 때, 소켓 통신을 활용하여 하는데, 이는 스크럼 때 정확하게 말씀드릴게요! 😄