### PR TITLE
Feature(HK-141): SSH Connection 수정을 위한 API 구현

### DIFF
--- a/src/main/java/kr/husk/domain/connection/entity/Connection.java
+++ b/src/main/java/kr/husk/domain/connection/entity/Connection.java
@@ -53,4 +53,12 @@ public class Connection extends BaseEntity {
         this.username = username;
         this.port = port;
     }
+
+    public void update(String name, String username, String host, String port, KeyChain keyChain) {
+        this.name = name;
+        this.host = host;
+        this.username = username;
+        this.keyChain = keyChain;
+        this.port = port;
+    }
 }

--- a/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
+++ b/src/main/java/kr/husk/domain/keychain/service/KeyChainService.java
@@ -13,6 +13,7 @@ import kr.husk.domain.keychain.repository.KeyChainRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -25,6 +26,7 @@ public class KeyChainService {
     private final EncryptionService encryptionService;
     private final KeyChainRepository keyChainRepository;
 
+    @Transactional
     public KeyChainDto.Response create(HttpServletRequest request, KeyChainDto.Request dto) {
         String accessToken = jwtProvider.resolveToken(request);
         String email = jwtProvider.getEmail(accessToken);
@@ -41,6 +43,7 @@ public class KeyChainService {
         return KeyChainDto.Response.of("키체인 등록이 완료되었습니다.");
     }
 
+    @Transactional
     public List<KeyChainDto.Overview> read(HttpServletRequest request) {
         String accessToken = jwtProvider.resolveToken(request);
         String email = jwtProvider.getEmail(accessToken);
@@ -49,6 +52,7 @@ public class KeyChainService {
         return KeyChainDto.Overview.from(user.getKeyChains());
     }
 
+    @Transactional
     public KeyChain read(User user, String name) {
         List<KeyChain> keyChainList = user.getKeyChains();
         for (KeyChain keyChain : keyChainList) {
@@ -59,6 +63,7 @@ public class KeyChainService {
         return null;
     }
 
+    @Transactional
     public KeyChainDto.Response update(HttpServletRequest request, KeyChainDto.UpdateRequest dto) {
         String accessToken = jwtProvider.resolveToken(request);
         String email = jwtProvider.getEmail(accessToken);
@@ -75,6 +80,7 @@ public class KeyChainService {
         return KeyChainDto.Response.of("키체인 수정이 완료되었습니다.");
     }
 
+    @Transactional
     public KeyChainDto.Response delete(HttpServletRequest request, Long id) {
         String accessToken = jwtProvider.resolveToken(request);
         String email = jwtProvider.getEmail(accessToken);
@@ -91,6 +97,7 @@ public class KeyChainService {
         return KeyChainDto.Response.of("키체인 삭제가 완료되었습니다.");
     }
 
+    @Transactional
     public KeyChainDto.Payload decrypt(HttpServletRequest request, Long id) {
         String accessToken = jwtProvider.resolveToken(request);
         String email = jwtProvider.getEmail(accessToken);

--- a/src/main/java/kr/husk/presentation/api/ConnectionApi.java
+++ b/src/main/java/kr/husk/presentation/api/ConnectionApi.java
@@ -41,4 +41,13 @@ public interface ConnectionApi {
             @ApiResponse(responseCode = "400", description = "커넥션 접속 실패")
     })
     ResponseEntity<?> connect(HttpServletRequest request, @PathVariable Long id);
+
+    @Operation(summary = "SSH 커넥션 수정", description = "SSH 커넥션 수정 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "SSH 커넥션 수정 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ConnectionInfoDto.Response.class))),
+            @ApiResponse(responseCode = "400", description = "SSH 커넥션 수정 실패")
+    })
+    ResponseEntity<?> update(HttpServletRequest request, @PathVariable Long id, @RequestBody ConnectionInfoDto.Request dto);
 }

--- a/src/main/java/kr/husk/presentation/rest/ConnectionController.java
+++ b/src/main/java/kr/husk/presentation/rest/ConnectionController.java
@@ -7,6 +7,7 @@ import kr.husk.presentation.api.ConnectionApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,4 +37,9 @@ public class ConnectionController implements ConnectionApi {
         return ResponseEntity.ok(connectionService.connect(request, id));
     }
 
+    @Override
+    @PatchMapping("/{id}")
+    public ResponseEntity<?> update(HttpServletRequest request, Long id, ConnectionInfoDto.Request dto) {
+        return ResponseEntity.ok(connectionService.update(request, id, dto));
+    }
 }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 사용자가 등록한 `Connection`의 수정을 위한 API 개발 필요.
- 사용자는 `Connection`을 잘못 등록 또는 수정이 필요한 경우 삭제 후 재등록할 필요가 없음.
- `Connection` 수정의 경우 `KeyChainName`을 변경할 시 기존에 사용자가 등록한 `KeyChain`을 기반으로 변경되어야 함.

## Problem Solving

<!-- 해결 방법 -->
- Controller 구현(c334b282e93953e68a600fbfbf5eab64ad64b88c), 비즈니스 로직 작성(f0597d9ed70f5edd165a2899e666cfdc7a297dce)
- `Connection Entity` 내에 `update` 메소드 추가(10f4fe0ab1f4f83227a965ca9165391e73f5cc7f)


## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 이외에 `KeyChain` 관련 비즈니스 로직 처리 부분에 `@Transactional` 어노테이션을 추가했습니다. (cf5bb046f7da85ea6dbc7147ca4fa55f76cca6a8)

<details><summary>API 테스트 결과</summary>

![image](https://github.com/user-attachments/assets/8fda7dfa-d34d-41bb-a8c3-4206133c5d72)

</details> 
