### PR TITLE
Feature(HK-142): 커넥션 삭제 API 구현

### DIFF
--- a/src/main/java/kr/husk/domain/connection/service/ConnectionService.java
+++ b/src/main/java/kr/husk/domain/connection/service/ConnectionService.java
@@ -98,6 +98,26 @@ public class ConnectionService {
         return ConnectionInfoDto.Response.of("커넥션 수정에 성공하였습니다.");
     }
 
+    @Transactional
+    public ConnectionInfoDto.Response delete(HttpServletRequest request, Long id) {
+        String accessToken = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(accessToken);
+
+        Connection connection = read(id);
+        if (!isAccessible(connection, email)) {
+            throw new GlobalException(ConnectionExceptionCode.CONNECTION_NOT_FOUND);
+        }
+
+        if (connection.isDeleted()) {
+            throw new GlobalException(ConnectionExceptionCode.CONNECTION_NOT_FOUND);
+        }
+
+        connection.delete();
+
+        log.info("사용자 {}의 {}번 커넥션({})이 삭제되었습니다.", email, id, connection.getName());
+        return ConnectionInfoDto.Response.of("커넥션 삭제가 완료되었습니다.");
+    }
+
     private boolean isAccessible(Connection connection, String email) {
         return connection.getUser().getEmail().equals(email);
     }

--- a/src/main/java/kr/husk/presentation/api/ConnectionApi.java
+++ b/src/main/java/kr/husk/presentation/api/ConnectionApi.java
@@ -50,4 +50,13 @@ public interface ConnectionApi {
             @ApiResponse(responseCode = "400", description = "SSH 커넥션 수정 실패")
     })
     ResponseEntity<?> update(HttpServletRequest request, @PathVariable Long id, @RequestBody ConnectionInfoDto.Request dto);
+
+    @Operation(summary = "SSH 커넥션 삭제", description = "SSH 커넥션 삭제 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "SSH 커넥션 삭제 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ConnectionInfoDto.Response.class))),
+            @ApiResponse(responseCode = "400", description = "SSH 커넥션 삭제 실패")
+    })
+    ResponseEntity<?> delete(HttpServletRequest request, @PathVariable Long id);
 }

--- a/src/main/java/kr/husk/presentation/rest/ConnectionController.java
+++ b/src/main/java/kr/husk/presentation/rest/ConnectionController.java
@@ -6,6 +6,7 @@ import kr.husk.domain.connection.service.ConnectionService;
 import kr.husk.presentation.api.ConnectionApi;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,5 +42,11 @@ public class ConnectionController implements ConnectionApi {
     @PatchMapping("/{id}")
     public ResponseEntity<?> update(HttpServletRequest request, Long id, ConnectionInfoDto.Request dto) {
         return ResponseEntity.ok(connectionService.update(request, id, dto));
+    }
+
+    @Override
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(HttpServletRequest request, Long id) {
+        return ResponseEntity.ok(connectionService.delete(request, id));
     }
 }


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 사용자가 등록한 커넥션을 삭제하기 위한 API 구현.
- `soft-delete` 방식을 통한 필드만 수정.

## Problem Solving

<!-- 해결 방법 -->
- `Controller` 구현 (34d5194b806a0602eacd456cbd436885524a9e4e)
- `Service` 비즈니스 로직 구현 (98fe01b0736814b2b49a5ad487132dc6dfcbbfa4)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- `deletedAt` 필드만 수정하면 되는데 기존 수정 API와 URI 경로가 겹쳐서 `HTTP Delete` 메소드를 사용하였습니다.

<details><summary>API 테스트 결과</summary>

![image](https://github.com/user-attachments/assets/bc9b8357-823e-48c9-9adf-b588a4c75685)


</details> 