### PR TITLE
Refactor(HK-146): SSH Connection 연결을 위한 라이브러리 수정 및 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,13 +52,12 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-orgjson', version: '0.11.2'
-    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.30.1'
 
     // Web Socket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     // SSH Connection
-    implementation 'com.jcraft:jsch:0.1.55'
+    implementation 'com.hierynomus:sshj:0.38.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/husk/infrastructure/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                                         "/api/v1/auth/sign-in",
                                         "/api/v1/auth/terms-of-service",
                                         "/api/v1/auth/password/reset",
+                                        "/ws/ssh-terminal",
                                         "/swagger-resources/**",
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- 이전의 `JSch` 라이브러리의 경우 현재 업데이트가 진행되지 않을뿐더러 SSH 연결을 위해서는 실제 `.pem` 파일을 경로로 등록하여 사용해야 한다고 함.
- 안정적인 커넥션 기능 구현을 위한 `SSHJ` 라이브러리 채택.
- 따라서, `JSch` 라이브러리에서 `SSHJ` 라이브러리로 변환을 위한 코드 리팩토링 필요.

## Problem Solving

<!-- 해결 방법 -->
- 라이브러리 관련 의존성 수정(0fd6ea2b7a413e7e638969711b10fcde6537fdbc)
- SSH Connection 관련 Handler 서비스 로직 리팩토링(168dfd44ef344eda2803880864320e0fb511390a)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 현재 원활한 작업을 위해 웹소켓 엔드포인트의 인증을 허용해놓은 상태입니다.
- FE에서는 시험 끝나고 새 스프린트 시작될 때, 어떤 작업을 하면 될지 얘기해보면 될 것 같습니다!

<details><summary>수정 후 연결 API 테스트</summary>

![image](https://github.com/user-attachments/assets/be609aa5-2404-4c60-aaac-de33a5d55b51)


</details> 