### PR TITLE
Feature(HK-154): Connection 세부 조회 API 구현

### DIFF
--- a/src/main/java/kr/husk/application/connection/dto/ConnectionInfoDto.java
+++ b/src/main/java/kr/husk/application/connection/dto/ConnectionInfoDto.java
@@ -75,4 +75,26 @@ public class ConnectionInfoDto {
             return parts[0] + "." + parts[1] + ".*.*";
         }
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(name = "ConnectionInfo.Details", description = "SSH 커넥션 조회에 대한 세부 정보 응답 DTO")
+    public static class Details {
+        private String name;
+        private String host;
+        private String username;
+        private String port;
+        private String keyChainName;
+
+        public static Details from(Connection connection) {
+            return Details.builder()
+                    .name(connection.getName())
+                    .host(connection.getHost())
+                    .username(connection.getUsername())
+                    .port(connection.getPort())
+                    .keyChainName(connection.getKeyChain().getName())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/kr/husk/domain/connection/service/ConnectionService.java
+++ b/src/main/java/kr/husk/domain/connection/service/ConnectionService.java
@@ -49,12 +49,27 @@ public class ConnectionService {
     }
 
     @Transactional
-    public List<ConnectionInfoDto.Summary> read(HttpServletRequest request) {
+    public List<ConnectionInfoDto.Summary> list(HttpServletRequest request) {
         String accessToken = jwtProvider.resolveToken(request);
         String email = jwtProvider.getEmail(accessToken);
 
         User user = userService.read(email);
         return ConnectionInfoDto.Summary.from(user.getConnections());
+    }
+
+    @Transactional
+    public ConnectionInfoDto.Details read(HttpServletRequest request, Long id) {
+        String accessToken = jwtProvider.resolveToken(request);
+        String email = jwtProvider.getEmail(accessToken);
+
+        User user = userService.read(email);
+        for (Connection connection : user.getConnections()) {
+            if (connection.getId() == id) {
+                return ConnectionInfoDto.Details.from(connection);
+            }
+        }
+
+        throw new GlobalException(ConnectionExceptionCode.CONNECTION_NOT_FOUND);
     }
 
     @Transactional

--- a/src/main/java/kr/husk/presentation/api/ConnectionApi.java
+++ b/src/main/java/kr/husk/presentation/api/ConnectionApi.java
@@ -24,14 +24,23 @@ public interface ConnectionApi {
     })
     ResponseEntity<?> create(HttpServletRequest request, @RequestBody ConnectionInfoDto.Request dto);
 
-    @Operation(summary = "SSH 커넥션 조회", description = "SSH 커넥션 조회 요청 API")
+    @Operation(summary = "SSH 커넥션 조회[목록]", description = "SSH 커넥션 조회 요청 API")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "SSH 커넥션 조회 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ConnectionInfoDto.Summary.class))),
             @ApiResponse(responseCode = "400", description = "SSH 커넥션 조회 실패")
     })
-    ResponseEntity<?> read(HttpServletRequest request);
+    ResponseEntity<?> list(HttpServletRequest request);
+
+    @Operation(summary = "SSH 커넥션 조회[세부사항]", description = "SSH 커넥션 세부 조회 요청 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "SSH 커넥션 세부 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ConnectionInfoDto.Details.class))),
+            @ApiResponse(responseCode = "400", description = "SSH 커넥션 세부 조회 실패")
+    })
+    ResponseEntity<?> read(HttpServletRequest request, @PathVariable Long id);
 
     @Operation(summary = "커넥션 접속 요청", description = "커넥션 접속 요청을 위한 API")
     @ApiResponses({

--- a/src/main/java/kr/husk/presentation/rest/ConnectionController.java
+++ b/src/main/java/kr/husk/presentation/rest/ConnectionController.java
@@ -28,8 +28,14 @@ public class ConnectionController implements ConnectionApi {
 
     @Override
     @GetMapping("")
-    public ResponseEntity<?> read(HttpServletRequest request) {
-        return ResponseEntity.ok(connectionService.read(request));
+    public ResponseEntity<?> list(HttpServletRequest request) {
+        return ResponseEntity.ok(connectionService.list(request));
+    }
+
+    @Override
+    @GetMapping("/{id}")
+    public ResponseEntity<?> read(HttpServletRequest request, Long id) {
+        return ResponseEntity.ok(connectionService.read(request, id));
     }
 
     @Override


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- `Connection` 목록에서 특정 항목 선택 시 수정, 삭제, 조회를 위한 API 구현 필요성 대두.
- 서비스 이용의 편의 및 UX 향상을 위한 API 추가 필요.

## Problem Solving

<!-- 해결 방법 -->
- 기존의 조회 API에 대한 메소드명 수정 (`read` → `list`) & 세부 조회를 위한 비즈니스 로직 추가 (3025fcf084c3128dc41e22789ae3fb346adaf454)
- DTO 클래스 정의 (7910e198fc8c24cf3da9f9e01f9892631695c509)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 혹시 추가적으로 구현이 필요하거나 반영이 필요한 사항이 있다면 말씀해주세요 😆

<details><summary>API 테스트</summary>
<p>

- 성공적으로 조회한 경우
![image](https://github.com/user-attachments/assets/655b7b4e-70fd-4acd-a0b0-1e0d8b2e096b)

- `connection id`가 틀린 경우
![image](https://github.com/user-attachments/assets/b21929d7-d13d-4015-8882-b0ffc60933e5)


</p>
</details> 