### PR TITLE
Refactor(HK-162): OAuth 계정 탈퇴 후 일반 계정으로 가입 시 로직 수정

### DIFF
--- a/src/main/java/kr/husk/application/auth/service/AuthService.java
+++ b/src/main/java/kr/husk/application/auth/service/AuthService.java
@@ -81,6 +81,7 @@ public class AuthService {
                 userService.update(user, dto.getPassword());
                 user.encodePassword(authConfig.passwordEncoder());
                 user.restore();
+                user.updateProvider(OAuthProvider.NONE);
             } else {
                 throw new GlobalException(UserExceptionCode.WITHDRAWN_USER);
             }

--- a/src/main/java/kr/husk/domain/auth/entity/User.java
+++ b/src/main/java/kr/husk/domain/auth/entity/User.java
@@ -57,4 +57,9 @@ public class User extends BaseEntity {
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
+
+
+    public void updateProvider(OAuthProvider oAuthProvider) {
+        this.oAuthProvider = oAuthProvider;
+    }
 }

--- a/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
+++ b/src/main/java/kr/husk/domain/auth/exception/AuthExceptionCode.java
@@ -14,7 +14,7 @@ public enum AuthExceptionCode implements ExceptionCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 리프레시 토큰입니다."),
     CONFIRM_PASSWORD_NOT_EQUAL(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),
-    OAUTH_UNLINK_FAILED(HttpStatus.BAD_REQUEST, "계정 연결 해제에 실패하였습니다.)");
+    OAUTH_UNLINK_FAILED(HttpStatus.BAD_REQUEST, "계정 연결 해제에 실패하였습니다.");
 
     HttpStatus httpStatus;
     String cause;


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- OAuth 계정을 탈퇴한 후 일반 계정으로 회원가입 할 경우, DB의 `oauth_provider` 속성이 수정되지 않는 문제 식별
- 사용자의 인증 관련 기능 이용 시 문제가 될 수 있기에 해당 문제를 해결할 필요성 대두

## Problem Solving

<!-- 해결 방법 -->
- `User` 테이블에서 해당 `oauth_provider` 속성을 `NONE`으로 수정하도록 로직 추가 (616e79898de5b21579d0742ced2ceb6349c9ed31)

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 테스트 완료하였고 정상적으로 작동합니다.
- 추가적으로, **_회원 탈퇴 후 30일 이내에 재가입을 시도 할 경우는 복구가 가능_** 하지만, **_30일이 초과되는 경우는 재가입이 이루어지지 않습니다._**