### PR TITLE
Fix(HK-168): Docker openjdk-17 미지원으로 인한 jdk 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk
+FROM eclipse-temurin:17-jdk
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-Dspring.profiles.active=docker", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk
+FROM amazoncorretto:17-alpine
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-Dspring.profiles.active=docker", "-jar", "app.jar"]


### PR DESCRIPTION
## Motivation

<!-- 작성 배경 -->
- EC2 장애 대응 후 WAS CD 재실행 과정에서 Docker의 openjdk-17 미지원 확인
  - 관련 docker 공식 문서: https://hub.docker.com/_/openjdk
- Docker를 사용한 재배포를 위해 다른 jdk 사용에 대한 필요성 대두

## Problem Solving

<!-- 해결 방법 -->
- Eclipse에서 제공하는 Temurin 적용하려고 했으나, AWS가 관리하는 `amazoncorretto:17`가 더 적합할 것 같아서 수정.
  - Amazon에서 만든 것이기 때문에 AWS 환경에서 안정성과 호환성이 높음.
  - 본 서비스의 인프라는 AWS 환경이므로 Temurin보다 더 나을 것이라고 판단
- AWS 지속적인 업데이트를 지원하고 있음.

## To Reviewer

<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- X